### PR TITLE
feat!: Use a more friendly docker tag format

### DIFF
--- a/pkg/util/helper.go
+++ b/pkg/util/helper.go
@@ -11,15 +11,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// NOTE(el): This is based off RFC3339 with some tweaks to make it a valid docker tag
+const dockerRFC3339TimeFmt string = "2006-01-02T15-04-05"
+
 func GenerateTag(config config.HappyConfig) (string, error) {
-	t := time.Now()
-	ts := fmt.Sprintf("%02d%02d-%02d%02d%02d", t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
 	userIdBackend := backend.GetAwsSts(config)
 	userName, err := userIdBackend.GetUserName()
 	if err != nil {
 		return "", err
 	}
-	tag := fmt.Sprintf("%s-%s", userName, ts)
+	t := time.Now().UTC().Format(dockerRFC3339TimeFmt)
+	tag := fmt.Sprintf("%s-%s", userName, t)
 
 	return tag, nil
 }


### PR DESCRIPTION
We base the tag format on ISO RFC3339 but make some slight tweaks such that it is compatible with docker tag character set. We do this because:
- they are sortable
- they are human readable
- they are machine readable

See https://go.dev/play/p/B3YnPqpVQk5 for an example and https://docs.docker.com/engine/reference/commandline/tag/ for character sets