### PR TITLE
fix: goreleaser needs full git history

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,10 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
 
       - uses: actions/checkout@v2
+        # we need to fetch all history and tags
+        # so we build the proper version
+        with:
+          fetch-depth: 0
         if: ${{ steps.release.outputs.release_created }}
 
       - uses: actions/setup-go@v2


### PR DESCRIPTION
Goreleaser needs more than a shallow clone so that it knows what to release and where to put it. Otherwise it'll always try v0.0.0. 

