### PR TITLE
fix!: match existing config key to auto_run_migrations

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -159,7 +159,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	autoRunMigration := happyConfig.AutoRunMigration()
+	autoRunMigration := happyConfig.AutoRunMigrations()
 	if autoRunMigration {
 		err = runMigrate(ctx, stackName)
 		if err != nil {

--- a/pkg/config/happy_config.go
+++ b/pkg/config/happy_config.go
@@ -158,7 +158,7 @@ func (s *HappyConfig) GetSecretArn() string {
 	return envConfig.SecretARN
 }
 
-func (s *HappyConfig) AutoRunMigration() bool {
+func (s *HappyConfig) AutoRunMigrations() bool {
 	envConfig := s.getEnvConfig()
 
 	return envConfig.AutoRunMigrations

--- a/pkg/config/happy_config.go
+++ b/pkg/config/happy_config.go
@@ -17,7 +17,7 @@ type Environment struct {
 	SecretARN          string     `yaml:"secret_arn"`
 	TerraformDirectory string     `yaml:"terraform_directory"`
 	DeleteProtected    bool       `yaml:"delete_protected"`
-	AutoRunMigration   bool       `yaml:"auto_run_migration"`
+	AutoRunMigrations  bool       `yaml:"auto_run_migrations"`
 	LogGroupPrefix     string     `yaml:"log_group_prefix"`
 	TaskLaunchType     LaunchType `yaml:"task_launch_type"`
 }
@@ -161,7 +161,7 @@ func (s *HappyConfig) GetSecretArn() string {
 func (s *HappyConfig) AutoRunMigration() bool {
 	envConfig := s.getEnvConfig()
 
-	return envConfig.AutoRunMigration
+	return envConfig.AutoRunMigrations
 }
 
 func (s *HappyConfig) LogGroupPrefix() string {

--- a/pkg/config/happy_config_test.go
+++ b/pkg/config/happy_config_test.go
@@ -11,15 +11,16 @@ var testFilePath = "testdata/test_config.yaml"
 
 func TestNewHappConfig(t *testing.T) {
 	testData := []struct {
-		env                string
-		wantAwsProfile     string
-		wantSecretArn      string
-		wantTfDir          string
-		wantTaskLaunchType string
+		env                   string
+		wantAwsProfile        string
+		wantSecretArn         string
+		wantTfDir             string
+		wantTaskLaunchType    string
+		wantAutorunMigrations bool
 	}{
-		{"rdev", "test-dev", "happy/env-rdev-config", ".happy/terraform/envs/rdev", "EC2"},
-		{"stage", "test-stage", "happy/env-stage-config", ".happy/terraform/envs/stage", "FARGATE"},
-		{"prod", "test-prod", "happy/env-prod-config", ".happy/terraform/envs/prod", "FARGATE"},
+		{"rdev", "test-dev", "happy/env-rdev-config", ".happy/terraform/envs/rdev", "EC2", true},
+		{"stage", "test-stage", "happy/env-stage-config", ".happy/terraform/envs/stage", "FARGATE", false},
+		{"prod", "test-prod", "happy/env-prod-config", ".happy/terraform/envs/prod", "FARGATE", false},
 	}
 
 	for idx, testCase := range testData {
@@ -33,6 +34,7 @@ func TestNewHappConfig(t *testing.T) {
 			r.Equal(config.DefaultEnv(), "rdev")
 			r.Equal(config.App(), "test-app")
 			r.Equal(config.SliceDefaultTag(), "branch-trunk")
+			r.Equal(testCase.wantAutorunMigrations, config.AutoRunMigrations())
 
 			tasks, _ := config.GetTasks("migrate")
 			r.Equal(tasks[0], "migrate_db_task_definition_arn")

--- a/pkg/config/testdata/test_config.yaml
+++ b/pkg/config/testdata/test_config.yaml
@@ -4,7 +4,7 @@ default_env: rdev
 app: test-app
 default_compose_env_file: ".env.ecr"
 slice_default_tag: "branch-trunk"
-services: 
+services:
     - frontend
     - backend
 slices:
@@ -24,6 +24,7 @@ environments:
         secret_arn: "happy/env-rdev-config"
         terraform_directory: ".happy/terraform/envs/rdev"
         log_group_prefix: "/dp/rdev"
+        auto_run_migrations: true
     stage:
         aws_profile: "test-stage"
         secret_arn: "happy/env-stage-config"


### PR DESCRIPTION
the python version uses `auto_run_migrations`, let's match it