### PR TITLE
fix: GitHub Release action s/jobs/needs/

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
   # We create a prerelease whenever wo DONT create a release
   prerelease:
     runs-on: ubuntu-latest
-    if: ${{ !jobs.release-please.outputs.release_created }}
+    if: ${{ !needs.release-please.outputs.release_created }}
     needs:
       - release-please
     steps:
@@ -91,5 +91,5 @@ jobs:
           version: latest
           args: release --rm-dist -f .goreleaser.prerelease.yml
         env:
-          GITHUB_TOKEN: ${{ jobs.release-please.outputs.goreleaser_token }}
+          GITHUB_TOKEN: ${{ needs.release-please.outputs.goreleaser_token }}
           GORELEASER_CURRENT_TAG: ${{ steps.generate_tag.outputs.tag-name }}


### PR DESCRIPTION
going by https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability, the contexts and their availability. in particular, s/jobs/needs/ context.