### PR TITLE
fix: Don't refer to docker-compose anymore

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,7 +17,7 @@ func init() {
 var buildCmd = &cobra.Command{
 	Use:          "build",
 	Short:        "build docker images",
-	Long:         "Build docker images using docker-compose",
+	Long:         "Build docker images using docker compose",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()

--- a/pkg/artifact_builder/builder_config.go
+++ b/pkg/artifact_builder/builder_config.go
@@ -130,7 +130,7 @@ func (s *BuilderConfig) GetBuildServicesImage() (map[string]string, error) {
 
 	svcs := map[string]string{}
 	for serviceName, service := range configData.Services {
-		// NOTE: we assume for now docker-compose services without a build section are for local development only
+		// NOTE: we assume for now docker compose services without a build section are for local development only
 		if service.Build == nil {
 			log.Debugf("%s doesn't have a build section defined, skipping", serviceName)
 			continue

--- a/pkg/artifact_builder/docker_compose.go
+++ b/pkg/artifact_builder/docker_compose.go
@@ -30,7 +30,7 @@ func (bc *BuilderConfig) DockerComposeConfig() (*ConfigData, error) {
 	configData := &ConfigData{}
 	err = yaml.Unmarshal(configDataBytes, configData)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not yaml parse docker-compose data")
+		return nil, errors.Wrap(err, "could not yaml parse docker compose data")
 	}
 	return configData, nil
 }
@@ -51,7 +51,7 @@ func (bc *BuilderConfig) invokeDockerCompose(command DockerCommand) ([]byte, err
 
 	docker, err := exec.LookPath("docker")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not find docker-compose in path")
+		return nil, errors.Wrap(err, "could not find docker compose in path")
 	}
 
 	cmd := &exec.Cmd{


### PR DESCRIPTION
We're using `docker compose` in the CLI rather than `docker-compose` so this updates error/help text and comments accordingly