### PR TITLE
fix: Docker uses buildkit

### DIFF
--- a/pkg/artifact_builder/docker_compose.go
+++ b/pkg/artifact_builder/docker_compose.go
@@ -47,7 +47,7 @@ func (bc *BuilderConfig) invokeDockerCompose(command DockerCommand) ([]byte, err
 
 	envVars := bc.GetBuildEnv()
 	envVars = append(envVars, os.Environ()...)
-	envVars = append(envVars, "DOCKER_BUILDKIT=0")
+	envVars = append(envVars, "DOCKER_BUILDKIT=1")
 
 	docker, err := exec.LookPath("docker")
 	if err != nil {


### PR DESCRIPTION
I'm not sure why buildkit is disabled in this CLI. It's enabled in the python script, and omission of buildkit is causing `docker compose` to ignore my `platform` flags.