### PR TITLE
fix: log stream when there is no log prefix set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.45.2
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes https://czi-tech.atlassian.net/browse/CCIE-503 where if the awslog-stream-prefix isn't set (like in [this task definition](https://github.com/chanzuckerberg/single-cell-explorer/blob/acd8932ffe09d980d57c7ab50b12b05816aa2709/.happy/terraform/modules/service/main.tf#L80)), there is no stream to pick. By default, happy will grab the latest log stream from the group. We should fix this using standarized TF modules for task definitions so that people don't forget to set a log prefix. 

See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html for more details:

> If you don't specify a prefix with this option, then the log stream is named after the container ID that's assigned by the Docker daemon on the container instance. Because it's difficult to trace logs back to the container that sent them with just the Docker container ID (which is only available on the container instance), we recommend that you specify a prefix with this option.