### PR TITLE
fix: specify version correctly

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -38,10 +38,16 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: cli/go.mod
+      - name: Parse Version
+        id: parse_version
+        uses: actions/github-script@v5
+        with:
+          result-encoding: string
+          script: return context.ref.replace('refs/tags/cli-', '')
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: ${{ steps.parse_version.outputs.result }}
           workdir: cli
           args: release --rm-dist
         env:


### PR DESCRIPTION
After changing tagging structure for the monorepo from `vX.X.X` to `cli-vX.X.X` goreleaser broke: https://github.com/chanzuckerberg/happy/actions/runs/3206117658/jobs/5239465071

This passes a version to goreleaser that does not have the `cli-` prefix