### PR TITLE
fix: create tag for goreleaser

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -44,6 +44,16 @@ jobs:
         with:
           result-encoding: string
           script: return context.ref.replace('refs/tags/cli-', '')
+      - name: Create overall repo tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.parse_version.outputs.result }}',
+              sha: context.sha
+            })
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/cli/file.txt
+++ b/cli/file.txt
@@ -1,1 +1,2 @@
 this file is only used to trigger releases and can be deleted after goreleaser is fixed
+


### PR DESCRIPTION
The tag needs to exist before goreleaser can use a custom version