### PR TITLE
fix: increase sleep time after tag creation

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -56,7 +56,7 @@ jobs:
                 sha: context.sha
               })
               // sleep to allow the new tag to sync so it will be available to goreleaser in the next step
-              await new Promise((resolve) => { setTimeout(resolve, 5000) })
+              await new Promise((resolve) => { setTimeout(resolve, 10000) })
             } catch(e) {
               // tag may have existed, ignore the error
               console.log(e)

--- a/cli/file.txt
+++ b/cli/file.txt
@@ -2,3 +2,4 @@ this file is only used to trigger releases and can be deleted after goreleaser i
 
 
 
+


### PR DESCRIPTION
This failed but a re-run will pass because the tag does exist: https://github.com/chanzuckerberg/happy/actions/runs/3228253227/jobs/5284105709

Increase the sleep time in hopes that the tag will sync and we can avoid the re-runs