### PR TITLE
chore: unpin release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,8 +30,7 @@
       "package-name": "shared"
     },
     "terraform/provider": {
-      "package-name": "terraform-provider",
-      "release-as": "0.39.0"
+      "package-name": "terraform-provider"
     }
   },
   "plugins": [


### PR DESCRIPTION
No longer need release to be pinned now that the initial terraform provider version has been released