### PR TITLE
fix: simplify staging/prod dns routing

### DIFF
--- a/.github/workflows/api-release-staging.yaml
+++ b/.github/workflows/api-release-staging.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - CCIE-842-simplify-prod-and-staging-urls
 
 name: api-release-staging
 jobs:

--- a/.github/workflows/api-release-staging.yaml
+++ b/.github/workflows/api-release-staging.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - CCIE-497-set-up-automated-deployment-of-happy-api-3
 
 name: api-release-staging
 jobs:

--- a/.github/workflows/api-release-staging.yaml
+++ b/.github/workflows/api-release-staging.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-      - CCIE-497-set-up-automated-deployment-of-happy-api-3
+      - CCIE-842-simplify-prod-and-staging-urls
 
 name: api-release-staging
 jobs:

--- a/api/.happy/terraform/envs/prod/main.tf
+++ b/api/.happy/terraform/envs/prod/main.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source                = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/happy-ecs-stack?ref=happy-ecs-stack-v0.155.0"
+  source                = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/happy-ecs-stack?ref=happy-ecs-stack-v0.156.0"
   app_name              = "happy-api"
   happy_config_secret   = var.happy_config_secret
   image_tag             = var.image_tag

--- a/api/.happy/terraform/envs/rdev/main.tf
+++ b/api/.happy/terraform/envs/rdev/main.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source                = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/happy-ecs-stack?ref=happy-ecs-stack-v0.155.0"
+  source                = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/happy-ecs-stack?ref=happy-ecs-stack-v0.156.0"
   app_name              = "happy-api"
   happy_config_secret   = var.happy_config_secret
   image_tag             = var.image_tag

--- a/api/.happy/terraform/envs/staging/main.tf
+++ b/api/.happy/terraform/envs/staging/main.tf
@@ -1,5 +1,5 @@
 module "stack" {
-  source                = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/happy-ecs-stack?ref=happy-ecs-stack-v0.155.0"
+  source                = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/happy-ecs-stack?ref=happy-ecs-stack-v0.156.0"
   app_name              = "happy-api"
   happy_config_secret   = var.happy_config_secret
   image_tag             = var.image_tag


### PR DESCRIPTION
staging is now accessible at https://happy-api.api.staging.si.czi.technology/health (instead of https://happy-api-happy-api.api.staging.si.czi.technology/health)