### PR TITLE
chore: bump version of proxy -- metrics

### DIFF
--- a/terraform/modules/happy-env-ecs/README.md
+++ b/terraform/modules/happy-env-ecs/README.md
@@ -26,7 +26,7 @@ Default happy path environment module that supports creating S3 buckets, RDS dat
 | <a name="module_db"></a> [db](#module\_db) | github.com/chanzuckerberg/cztack//aws-aurora-postgres | v0.49.0 |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecr-repository | v0.227.0 |
 | <a name="module_ecs-cluster"></a> [ecs-cluster](#module\_ecs-cluster) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-cluster | ecs-cluster-v1.0.1 |
-| <a name="module_ecs-multi-domain-oauth-proxy"></a> [ecs-multi-domain-oauth-proxy](#module\_ecs-multi-domain-oauth-proxy) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-multi-domain-oauth-proxy | ecs-multi-domain-oauth-proxy-v1.1.0 |
+| <a name="module_ecs-multi-domain-oauth-proxy"></a> [ecs-multi-domain-oauth-proxy](#module\_ecs-multi-domain-oauth-proxy) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-multi-domain-oauth-proxy | ecs-multi-domain-oauth-proxy-v1.3.0 |
 | <a name="module_happy_github_ci_role"></a> [happy\_github\_ci\_role](#module\_happy\_github\_ci\_role) | ../happy-github-ci-role | n/a |
 | <a name="module_instance-cloud-init-script"></a> [instance-cloud-init-script](#module\_instance-cloud-init-script) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/instance-cloud-init-script | v0.227.0 |
 | <a name="module_integration_secret_reader_policy"></a> [integration\_secret\_reader\_policy](#module\_integration\_secret\_reader\_policy) | git@github.com:chanzuckerberg/cztack//aws-iam-secrets-reader-policy | v0.43.3 |

--- a/terraform/modules/happy-env-ecs/proxy.tf
+++ b/terraform/modules/happy-env-ecs/proxy.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role" "proxy_role" {
 
 module "ecs-multi-domain-oauth-proxy" {
   count  = length(var.private_lb_services) > 0 ? 1 : 0
-  source = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-multi-domain-oauth-proxy?ref=ecs-multi-domain-oauth-proxy-v1.1.0"
+  source = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-multi-domain-oauth-proxy?ref=ecs-multi-domain-oauth-proxy-v1.3.0"
   cloud-env = {
     public_subnets  = var.cloud-env.public_subnets,
     private_subnets = var.cloud-env.private_subnets,

--- a/terraform/modules/happy-env-eks/README.md
+++ b/terraform/modules/happy-env-eks/README.md
@@ -26,7 +26,7 @@ https://docs.google.com/drawings/d/1AsJts2qCmw7685A6WZPDb5ApkXyuPRc27Lg3zzWuPaA/
 | <a name="module_dbs"></a> [dbs](#module\_dbs) | github.com/chanzuckerberg/cztack//aws-aurora-postgres | v0.49.0 |
 | <a name="module_ecrs"></a> [ecrs](#module\_ecrs) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecr-repository | main |
 | <a name="module_happy_github_ci_role"></a> [happy\_github\_ci\_role](#module\_happy\_github\_ci\_role) | ../happy-github-ci-role | n/a |
-| <a name="module_proxy"></a> [proxy](#module\_proxy) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/eks-multi-domain-oauth-proxy | eks-multi-domain-oauth-proxy-v1.2.0 |
+| <a name="module_proxy"></a> [proxy](#module\_proxy) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/eks-multi-domain-oauth-proxy | eks-multi-domain-oauth-proxy-v1.3.0 |
 | <a name="module_s3_buckets"></a> [s3\_buckets](#module\_s3\_buckets) | github.com/chanzuckerberg/cztack//aws-s3-private-bucket | v0.43.1 |
 
 ## Resources

--- a/terraform/modules/happy-env-eks/proxy.tf
+++ b/terraform/modules/happy-env-eks/proxy.tf
@@ -24,7 +24,7 @@ resource "aws_route53_record" "happy_prefixed" {
 }
 
 module "proxy" {
-  source = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/eks-multi-domain-oauth-proxy?ref=eks-multi-domain-oauth-proxy-v1.2.0"
+  source = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/eks-multi-domain-oauth-proxy?ref=eks-multi-domain-oauth-proxy-v1.3.0"
 
   tags      = var.tags
   eks       = var.eks-cluster


### PR DESCRIPTION
Update the happy modules to the latest versions of the proxy which expose metrics on the nginx and oauth2_proxy containers.