### PR TITLE
fix: stack only getting added when empty

### DIFF
--- a/cli/pkg/stack_mgr/stack_meta.go
+++ b/cli/pkg/stack_mgr/stack_meta.go
@@ -40,7 +40,7 @@ func (s *StackMeta) Update(
 	}
 	s.DataMap["imagetags"] = string(imageTagsJson)
 
-	if sliceName == "" {
+	if sliceName != "" {
 		s.DataMap["slice"] = sliceName
 	}
 


### PR DESCRIPTION
This PR fixes a bug where the slice was only being added to the Terraform workspace when it was empty. This will allow people to use the slice variable in their terraform configuration to do dynamic stacks based on a slice update.