### PR TITLE
fix: happy env ecs

### DIFF
--- a/terraform/modules/happy-env-ecs/README.md
+++ b/terraform/modules/happy-env-ecs/README.md
@@ -26,7 +26,7 @@ Default happy path environment module that supports creating S3 buckets, RDS dat
 | <a name="module_db"></a> [db](#module\_db) | github.com/chanzuckerberg/cztack//aws-aurora-postgres | v0.49.0 |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecr-repository | v0.227.0 |
 | <a name="module_ecs-cluster"></a> [ecs-cluster](#module\_ecs-cluster) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-cluster | ecs-cluster-v1.0.1 |
-| <a name="module_ecs-multi-domain-oauth-proxy"></a> [ecs-multi-domain-oauth-proxy](#module\_ecs-multi-domain-oauth-proxy) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-multi-domain-oauth-proxy | ecs-multi-domain-oauth-proxy-v1.3.1 |
+| <a name="module_ecs-multi-domain-oauth-proxy"></a> [ecs-multi-domain-oauth-proxy](#module\_ecs-multi-domain-oauth-proxy) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-multi-domain-oauth-proxy | ecs-multi-domain-oauth-proxy-v1.3.2 |
 | <a name="module_happy_github_ci_role"></a> [happy\_github\_ci\_role](#module\_happy\_github\_ci\_role) | ../happy-github-ci-role | n/a |
 | <a name="module_instance-cloud-init-script"></a> [instance-cloud-init-script](#module\_instance-cloud-init-script) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/instance-cloud-init-script | v0.227.0 |
 | <a name="module_integration_secret_reader_policy"></a> [integration\_secret\_reader\_policy](#module\_integration\_secret\_reader\_policy) | git@github.com:chanzuckerberg/cztack//aws-iam-secrets-reader-policy | v0.43.3 |

--- a/terraform/modules/happy-env-ecs/proxy.tf
+++ b/terraform/modules/happy-env-ecs/proxy.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role" "proxy_role" {
 
 module "ecs-multi-domain-oauth-proxy" {
   count  = length(var.private_lb_services) > 0 ? 1 : 0
-  source = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-multi-domain-oauth-proxy?ref=ecs-multi-domain-oauth-proxy-v1.3.1"
+  source = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/ecs-multi-domain-oauth-proxy?ref=ecs-multi-domain-oauth-proxy-v1.3.2"
   cloud-env = {
     public_subnets  = var.cloud-env.public_subnets,
     private_subnets = var.cloud-env.private_subnets,


### PR DESCRIPTION
Reverting to using our old image so that we can use Chamber to pull secrets. New fargate networking prevents us from calling SSM.