### PR TITLE
feat: add synthetics to happy stack services

### DIFF
--- a/terraform/modules/happy-stack-eks/README.md
+++ b/terraform/modules/happy-stack-eks/README.md
@@ -5,12 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.45 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.20.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.20.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.16 |
 
 ## Modules
@@ -24,6 +26,8 @@
 
 | Name | Type |
 |------|------|
+| [datadog_synthetics_test.test_api](https://registry.terraform.io/providers/datadog/datadog/latest/docs/resources/synthetics_test) | resource |
+| [datadog_synthetics_locations.locations](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/synthetics_locations) | data source |
 | [kubernetes_secret.integration_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/secret) | data source |
 
 ## Inputs
@@ -40,7 +44,7 @@
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Please provide a default image tag | `string` | n/a | yes |
 | <a name="input_image_tags"></a> [image\_tags](#input\_image\_tags) | Override image tag for each docker image | `map(string)` | `{}` | no |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | K8S namespace for this stack | `string` | n/a | yes |
-| <a name="input_services"></a> [services](#input\_services) | The services you want to deploy as part of this stack. | <pre>map(object({<br>    name : string,<br>    service_type : string,<br>    desired_count : number,<br>    port : number,<br>    memory : string,<br>    cpu : string,<br>    health_check_path : optional(string, "/"),<br>    aws_iam_policy_json : optional(string, ""),<br>  }))</pre> | n/a | yes |
+| <a name="input_services"></a> [services](#input\_services) | The services you want to deploy as part of this stack. | <pre>map(object({<br>    name : string,<br>    service_type : string,<br>    desired_count : number,<br>    port : number,<br>    memory : string,<br>    cpu : string,<br>    health_check_path : optional(string, "/"),<br>    aws_iam_policy_json : optional(string, ""),<br>    synthetics : optional(bool, false)<br>  }))</pre> | n/a | yes |
 | <a name="input_stack_name"></a> [stack\_name](#input\_stack\_name) | Happy Path stack name | `string` | n/a | yes |
 | <a name="input_stack_prefix"></a> [stack\_prefix](#input\_stack\_prefix) | Do bucket storage paths and db schemas need to be prefixed with the stack name? (Usually '/{stack\_name}' for dev stacks, and '' for staging/prod stacks) | `string` | `""` | no |
 | <a name="input_tasks"></a> [tasks](#input\_tasks) | The deletion/migration tasks you want to run when a stack comes up and down. | <pre>map(object({<br>    image : string,<br>    memory : string,<br>    cpu : string,<br>    cmd : set(string),<br>  }))</pre> | n/a | yes |

--- a/terraform/modules/happy-stack-eks/synthetics.tf
+++ b/terraform/modules/happy-stack-eks/synthetics.tf
@@ -1,0 +1,39 @@
+locals {
+  synthetics = {for k, v in local.service_definitions : v.service_name =>
+    v.service_type == "EXTERNAL" ? "https://${v.service_name}.${local.external_dns}/${v.health_check_path}" : "https://${v.service_name}.${local.internal_dns}/${v.health_check_path}"
+    if v.synthetics
+  }
+}
+
+data "datadog_synthetics_locations" "locations" {}
+
+resource "datadog_synthetics_test" "test_api" {
+  for_each = local.synthetics
+  type     = "api"
+  subtype  = "http"
+  request_definition {
+    method = "GET"
+    url    = each.value
+  }
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "200"
+  }
+  locations = keys(data.datadog_synthetics_locations.locations.locations)
+  options_list {
+    tick_every = 900
+
+    retry {
+      count    = 2
+      interval = 300
+    }
+
+    monitor_options {
+      renotify_interval = 120
+    }
+  }
+  name    = "A website synthetic for the happy stack ${var.deployment_stage} ${var.stack_name} ${each.key} located at ${each.value}"
+  message = "Notify @opsgenie-${var.stack_name}-${var.deployment_stage}-${each.key}"
+  status = "live"
+}

--- a/terraform/modules/happy-stack-eks/synthetics.tf
+++ b/terraform/modules/happy-stack-eks/synthetics.tf
@@ -1,6 +1,9 @@
 locals {
-  synthetics = {for k, v in local.service_definitions : v.service_name =>
-    v.service_type == "EXTERNAL" ? "https://${v.service_name}.${local.external_dns}/${v.health_check_path}" : "https://${v.service_name}.${local.internal_dns}/${v.health_check_path}"
+  # this is making an assumption that the health check path is accessible to the internet
+  # if this is a non-prod OIDC protected stack, make sure to allow the health check endpoint
+  # through the OIDC proxy.
+  synthetics = { for k, v in local.service_definitions : v.service_name =>
+    v.service_type == "EXTERNAL" ? "https://${v.service_name}.${local.external_dns}${v.health_check_path}" : "https://${v.service_name}.${local.internal_dns}${v.health_check_path}"
     if v.synthetics
   }
 }
@@ -35,5 +38,5 @@ resource "datadog_synthetics_test" "test_api" {
   }
   name    = "A website synthetic for the happy stack ${var.deployment_stage} ${var.stack_name} ${each.key} located at ${each.value}"
   message = "Notify @opsgenie-${var.stack_name}-${var.deployment_stage}-${each.key}"
-  status = "live"
+  status  = "live"
 }

--- a/terraform/modules/happy-stack-eks/variables.tf
+++ b/terraform/modules/happy-stack-eks/variables.tf
@@ -68,6 +68,7 @@ variable "services" {
     cpu : string,
     health_check_path : optional(string, "/"),
     aws_iam_policy_json : optional(string, ""),
+    synthetics: optional(bool, false)
   }))
   description = "The services you want to deploy as part of this stack."
 }

--- a/terraform/modules/happy-stack-eks/variables.tf
+++ b/terraform/modules/happy-stack-eks/variables.tf
@@ -68,7 +68,7 @@ variable "services" {
     cpu : string,
     health_check_path : optional(string, "/"),
     aws_iam_policy_json : optional(string, ""),
-    synthetics: optional(bool, false)
+    synthetics : optional(bool, false)
   }))
   description = "The services you want to deploy as part of this stack."
 }

--- a/terraform/modules/happy-stack-eks/versions.tf
+++ b/terraform/modules/happy-stack-eks/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = ">= 2.16"
     }
     datadog = {
-      source = "datadog/datadog"
+      source  = "datadog/datadog"
       version = ">= 3.20.0"
     }
   }

--- a/terraform/modules/happy-stack-eks/versions.tf
+++ b/terraform/modules/happy-stack-eks/versions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.16"
     }
+    datadog = {
+      source = "datadog/datadog"
+      version = ">= 3.20.0"
+    }
   }
   required_version = ">= 1.3"
 }


### PR DESCRIPTION
Example: https://app.datadoghq.com/synthetics/details/thu-n4e-6e5

Looks like this:

![Screenshot 2023-01-23 at 2 55 28 PM](https://user-images.githubusercontent.com/76011913/214170886-ed2f7670-3032-4e44-a4f8-ae5693445820.png)

If you choose to opt in (probably most effective for production deployments), you can turn on synthetic testing of your services in EKS.