### PR TITLE
fix: push command to push to stack ECRs

### DIFF
--- a/cli/cmd/push.go
+++ b/cli/cmd/push.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/chanzuckerberg/happy/cli/pkg/artifact_builder"
-	backend "github.com/chanzuckerberg/happy/cli/pkg/backend/aws"
+	happyCmd "github.com/chanzuckerberg/happy/cli/pkg/cmd"
 	"github.com/chanzuckerberg/happy/cli/pkg/config"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -19,38 +19,32 @@ func init() {
 }
 
 var pushCmd = &cobra.Command{
-	Use:          "push",
+	Use:          "push STACK_NAME",
 	Short:        "Push docker images",
 	Long:         "Push docker images to ECR",
 	SilenceUsage: true,
+	PreRunE: happyCmd.Validate(
+		cobra.ExactArgs(1),
+		happyCmd.IsStackNameDNSCharset,
+		happyCmd.IsStackNameAlphaNumeric),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		stackName := args[0]
+		happyClient, err := makeHappyClient(cmd, sliceName, stackName, tag, createTag, dryRun)
+		if err != nil {
+			return errors.Wrap(err, "unable to initialize the happy client")
+		}
+
 		ctx := cmd.Context()
-		bootstrapConfig, err := config.NewBootstrapConfig(cmd)
+		err = validate(
+			validateGitTree(happyClient.HappyConfig.GetProjectRoot()),
+			validateStackNameAvailable(ctx, happyClient.StackService, stackName, force),
+			validateStackExistsCreate(ctx, stackName, dryRun, happyClient),
+			validateECRExists(ctx, stackName, dryRun, terraformECRTargetPathTemplate, happyClient),
+		)
 		if err != nil {
-			return err
-		}
-		happyConfig, err := config.NewHappyConfig(bootstrapConfig)
-		if err != nil {
-			return err
+			return errors.Wrap(err, "failed one of the happy client validations")
 		}
 
-		b, err := backend.NewAWSBackend(ctx, happyConfig)
-		if err != nil {
-			return err
-		}
-
-		buildConfig := artifact_builder.NewBuilderConfig().WithBootstrap(bootstrapConfig).WithHappyConfig(happyConfig)
-		// FIXME: this is an error-prone interface
-		if sliceName != "" {
-			slice, err := happyConfig.GetSlice(sliceName)
-			if err != nil {
-				return err
-			}
-			buildConfig.Profile = slice.Profile
-		}
-
-		artifactBuilder := artifact_builder.CreateArtifactBuilder().WithConfig(buildConfig).WithBackend(b).WithTags(tags)
-
-		return artifactBuilder.BuildAndPush(ctx)
+		return happyClient.ArtifactBuilder.BuildAndPush(ctx)
 	},
 }

--- a/cli/pkg/cmd/validate.go
+++ b/cli/pkg/cmd/validate.go
@@ -10,13 +10,11 @@ import (
 
 func Validate(vs ...cobra.PositionalArgs) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		var err *multierror.Error
 		for _, v := range vs {
-			err = multierror.Append(err, v(cmd, args))
-		}
-		// If argument validation fails, print help
-		if err.ErrorOrNil() != nil {
-			return multierror.Append(err, cmd.Help())
+			err := v(cmd, args)
+			if err != nil {
+				return multierror.Append(err, cmd.Help())
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
This PR updates the push command so that it pushes to the ECRs that are specific to the stack name provided. Before, no stack argument was required.