### PR TITLE
feat: CCIE-858: lock the version of happy cli in a repo like fogg

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -85,6 +85,10 @@ var rootCmd = &cobra.Command{
 		err = util.ValidateEnvironment(cmd.Context())
 		return errors.Wrap(err, "local environment is misconfigured")
 	},
+
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		WarnIfHappyOutdated(cmd)
+	},
 }
 
 // Execute executes the command
@@ -107,8 +111,6 @@ func Execute() error {
 			log.Warn(warning)
 		}
 	}
-
-	WarnIfHappyOutdated(rootCmd)
 
 	return nil
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -114,17 +114,3 @@ func Execute() error {
 
 	return nil
 }
-
-func WarnIfHappyOutdated(cmd *cobra.Command) {
-	outdated, cliVersion, latestAvailableVersion, err := IsHappyOutdated(cmd)
-
-	if err != nil {
-		log.Errorf("Error checking for latest available version number: %v", err)
-		return
-	}
-
-	if outdated {
-		log.Warnf("This copy of Happy CLI is not the latest available. CLI version: %s  Latest available version: %s\n", cliVersion.Version, latestAvailableVersion.Version)
-		log.Warn("To update on Mac, run:  brew upgrade happy")
-	}
-}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -82,7 +82,8 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if err = CheckLockedHappyVersion(cmd); err != nil {
+		err = CheckLockedHappyVersion(cmd)
+		if err != nil {
 			return err
 		}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -87,9 +87,7 @@ var rootCmd = &cobra.Command{
 			return errors.Wrap(err, "Unable to verify locked Happy version")
 		} else {
 			if !versionMatch {
-				return errors.New(
-					fmt.Sprintf("Installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion),
-				)
+				return errors.Errorf("Installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
 			}
 		}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -82,6 +82,14 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		if versionMatch, err := VerifyHappyIsLockedVersion(cmd); err != nil {
+			return errors.Wrap(err, "Unable to verify locked Happy version")
+		} else {
+			if !versionMatch {
+				return errors.New("Installed Happy version does not match locked version in .happy/version.lock")
+			}
+		}
+
 		err = util.ValidateEnvironment(cmd.Context())
 		return errors.Wrap(err, "local environment is misconfigured")
 	},

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"time"
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"time"
 
@@ -25,8 +24,6 @@ const (
 
 var OutputFormat string = "text"
 var Interactive bool = true
-
-var excludeVersionCheckCmds = map[string]interface{}{"version": nil, "set-lock": nil}
 
 func init() {
 	rootCmd.PersistentFlags().BoolP(flagVerbose, "v", false, "Use this to enable verbose mode")
@@ -85,17 +82,8 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		fmt.Printf("Current command: %s\n", cmd.CalledAs())
-		if _, present := excludeVersionCheckCmds[cmd.CalledAs()]; !present {
-			if versionMatch, cliVersion, lockedVersion, err := VerifyHappyIsLockedVersion(cmd); err != nil {
-				return errors.Wrap(err, "Unable to verify locked Happy version")
-			} else {
-				if !versionMatch {
-					return errors.Errorf("Installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
-				}
-			}
-		} else {
-			log.Debug("Skipping locked version check")
+		if err = CheckLockedHappyVersion(cmd); err != nil {
+			return err
 		}
 
 		err = util.ValidateEnvironment(cmd.Context())

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -82,11 +83,13 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if versionMatch, err := VerifyHappyIsLockedVersion(cmd); err != nil {
+		if versionMatch, cliVersion, lockedVersion, err := VerifyHappyIsLockedVersion(cmd); err != nil {
 			return errors.Wrap(err, "Unable to verify locked Happy version")
 		} else {
 			if !versionMatch {
-				return errors.New("Installed Happy version does not match locked version in .happy/version.lock")
+				return errors.New(
+					fmt.Sprintf("Installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion),
+				)
 			}
 		}
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -186,16 +186,18 @@ func VerifyHappyIsLockedVersion(cmd *cobra.Command) (bool, string, string, error
 
 func CheckLockedHappyVersion(cmd *cobra.Command) error {
 
-	excludeVersionCheckCmds := map[string]interface{}{
+	excludeLockedVersionCheckCmds := map[string]interface{}{
 		"version":           nil,
 		"set-lock":          nil,
 		"available-version": nil,
 	}
 
 	log.Debugf("Current command: %s\n", cmd.CalledAs())
-	if _, present := excludeVersionCheckCmds[cmd.CalledAs()]; !present {
+	if _, present := excludeLockedVersionCheckCmds[cmd.CalledAs()]; !present {
 		if versionMatch, cliVersion, lockedVersion, err := VerifyHappyIsLockedVersion(cmd); err != nil {
-			return errors.Wrap(err, "Unable to verify locked Happy version")
+			// This is generally going to be because we are outside of a project root.
+			log.Debugf("Unable to verify locked Happy version: %s", err)
+			return nil
 		} else {
 			if !versionMatch {
 				return errors.Errorf("Installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -56,7 +56,7 @@ var lockHappyVersionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		versionFile, version, err := CreateHappyVersionFile(cmd)
 		if err != nil {
-			fmt.Fprint(cmd.Parent().ErrOrStderr(), err)
+			log.Debug(cmd.Parent().ErrOrStderr(), err)
 			return err
 		}
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/chanzuckerberg/happy/cli/pkg/config"
 	"github.com/chanzuckerberg/happy/cli/pkg/hapi"
@@ -127,16 +125,27 @@ func CreateHappyVersionFile(cmd *cobra.Command) (string, string, error) {
 		requestedVersion = currentVersion.Version
 	}
 
-	versionFilePath := filepath.Join(projectRoot, ".happy", "version.lock")
-	happyVersionFile, err := os.Create(versionFilePath)
+	versionFile := config.NewHappyVersionLockFile(projectRoot)
 
+	err = versionFile.SetVersion(requestedVersion)
 	if err != nil {
-		log.Errorf("Could not create %s: %v", versionFilePath, err)
+		return "", "", err
 	}
 
-	happyVersionFile.WriteString(requestedVersion)
-	happyVersionFile.Sync()
-	happyVersionFile.Close()
+	err = versionFile.Save()
+	if err != nil {
+		return "", "", err
+	}
 
-	return versionFilePath, requestedVersion, nil
+	versionFilePath, err := versionFile.GetPath()
+	if err != nil {
+		return "", "", err
+	}
+
+	version, err := versionFile.GetVersion()
+	if err != nil {
+		return "", "", err
+	}
+
+	return versionFilePath, version, nil
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -198,10 +198,10 @@ func CheckLockedHappyVersion(cmd *cobra.Command) error {
 			// This is generally going to be because we are outside of a project root.
 			log.Debugf("Unable to verify locked Happy version: %s", err)
 			return nil
-		} else {
+		} 
 			if !versionMatch {
 				return errors.Errorf("Installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
-			}
+			
 		}
 	}
 	log.Debug("Skipping locked version check")

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -18,7 +18,7 @@ func init() {
 	versionCmd.AddCommand(availableVersionCmd)
 
 	versionCmd.AddCommand(lockHappyVersionCmd)
-	lockHappyVersionCmd.Flags().String("version", "", "Specify a version of Happy for .happy-version file. Default to current CLI version.")
+	lockHappyVersionCmd.Flags().String("version", "", "Specify a version of Happy to lock in .happy/version.lock file. Default to current CLI version.")
 }
 
 var versionCmd = &cobra.Command{

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -109,7 +109,6 @@ func WarnIfHappyOutdated(cmd *cobra.Command) {
 		log.Warnf("This copy of Happy CLI is not the latest available. CLI version: %s  Latest available version: %s\n", cliVersion.Version, latestAvailableVersion.Version)
 		log.Warn("To update on Mac, run:  brew upgrade happy")
 	}
-
 }
 
 func CreateHappyVersionLockfileHandler(cmd *cobra.Command) error {
@@ -136,7 +135,6 @@ func CreateHappyVersionLockfileHandler(cmd *cobra.Command) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "Created %s locking Happy to version %s\n", path, version)
 
 	return nil
-
 }
 
 func createHappyVersionLockFile(projectRoot string, requestedVersion string) (string, string, error) {
@@ -210,5 +208,4 @@ func CheckLockedHappyVersion(cmd *cobra.Command) error {
 	}
 
 	return nil
-
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -49,7 +49,7 @@ var availableVersionCmd = &cobra.Command{
 }
 
 var lockHappyVersionCmd = &cobra.Command{
-	Use:          "lock",
+	Use:          "set-lock",
 	Short:        "Create a .happy/version.lock file",
 	Long:         "Create a .happy/version.lock file in project root to specify which version of Happy should be used with this project. This will overwrite any existing version.lock file.",
 	SilenceUsage: true,

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -194,7 +194,8 @@ func CheckLockedHappyVersion(cmd *cobra.Command) error {
 
 	log.Debugf("Current command: %s\n", cmd.CalledAs())
 	if _, present := excludeLockedVersionCheckCmds[cmd.CalledAs()]; !present {
-		if versionMatch, cliVersion, lockedVersion, err := VerifyHappyIsLockedVersion(cmd); err != nil {
+		versionMatch, cliVersion, lockedVersion, err := VerifyHappyIsLockedVersion(cmd)
+		if err != nil {
 			// This is generally going to be because we are outside of a project root.
 			log.Debugf("Unable to verify locked Happy version: %s", err)
 			return nil

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -149,3 +149,33 @@ func CreateHappyVersionFile(cmd *cobra.Command) (string, string, error) {
 
 	return versionFilePath, version, nil
 }
+
+func VerifyHappyIsLockedVersion(cmd *cobra.Command) (bool, error) {
+	happyConfig, err := config.GetHappyConfigForCmd(cmd)
+	if err != nil {
+		return false, err
+	}
+
+	projectRoot := happyConfig.GetProjectRoot()
+
+	/*
+		For backward compatibility reasons, if the .happy/version.lock file does not exist,
+		we will simply return true. We are essentially saying that an unlocked version is the same
+		as when an version is locked and matched.
+	*/
+
+	if !config.DoesHappyVersionLockFileExist(projectRoot) {
+		return true, nil
+	}
+
+	happyVersionLock, err := config.LoadHappyVersionLockFile(projectRoot)
+	if err != nil {
+		return false, err
+	}
+
+	if util.GetVersion().Version != happyVersionLock.HappyVersion {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -125,9 +125,7 @@ func CreateHappyVersionFile(cmd *cobra.Command) (string, string, error) {
 		requestedVersion = currentVersion.Version
 	}
 
-	versionFile := config.NewHappyVersionLockFile(projectRoot)
-
-	err = versionFile.SetVersion(requestedVersion)
+	versionFile, err := config.NewHappyVersionLockFile(projectRoot, requestedVersion)
 	if err != nil {
 		return "", "", err
 	}
@@ -137,17 +135,7 @@ func CreateHappyVersionFile(cmd *cobra.Command) (string, string, error) {
 		return "", "", err
 	}
 
-	versionFilePath, err := versionFile.GetPath()
-	if err != nil {
-		return "", "", err
-	}
-
-	version, err := versionFile.GetVersion()
-	if err != nil {
-		return "", "", err
-	}
-
-	return versionFilePath, version, nil
+	return versionFile.Path, versionFile.HappyVersion, nil
 }
 
 func VerifyHappyIsLockedVersion(cmd *cobra.Command) (bool, string, string, error) {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -203,8 +203,7 @@ func CheckLockedHappyVersion(cmd *cobra.Command) error {
 				return errors.Errorf("Installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
 			}
 		}
-	} else {
-		log.Debug("Skipping locked version check")
 	}
+	log.Debug("Skipping locked version check")
 	return nil
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -193,18 +193,22 @@ func CheckLockedHappyVersion(cmd *cobra.Command) error {
 	}
 
 	log.Debugf("Current command: %s\n", cmd.CalledAs())
-	if _, present := excludeLockedVersionCheckCmds[cmd.CalledAs()]; !present {
-		versionMatch, cliVersion, lockedVersion, err := VerifyHappyIsLockedVersion(cmd)
-		if err != nil {
-			// This is generally going to be because we are outside of a project root.
-			log.Debugf("Unable to verify locked Happy version: %s", err)
-			return nil
-		} 
-			if !versionMatch {
-				return errors.Errorf("installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
-			
-		}
+	if _, present := excludeLockedVersionCheckCmds[cmd.CalledAs()]; present {
+		log.Debug("Skipping locked version check")
+		return nil
 	}
-	log.Debug("Skipping locked version check")
+
+	versionMatch, cliVersion, lockedVersion, err := VerifyHappyIsLockedVersion(cmd)
+	if err != nil {
+		// This is generally going to be because we are outside of a project root.
+		log.Debugf("Unable to verify locked Happy version: %s", err)
+		return nil
+	}
+
+	if !versionMatch {
+		return errors.Errorf("installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
+	}
+
 	return nil
+
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -150,10 +150,10 @@ func CreateHappyVersionFile(cmd *cobra.Command) (string, string, error) {
 	return versionFilePath, version, nil
 }
 
-func VerifyHappyIsLockedVersion(cmd *cobra.Command) (bool, error) {
+func VerifyHappyIsLockedVersion(cmd *cobra.Command) (bool, string, string, error) {
 	happyConfig, err := config.GetHappyConfigForCmd(cmd)
 	if err != nil {
-		return false, err
+		return false, "", "", err
 	}
 
 	projectRoot := happyConfig.GetProjectRoot()
@@ -165,17 +165,17 @@ func VerifyHappyIsLockedVersion(cmd *cobra.Command) (bool, error) {
 	*/
 
 	if !config.DoesHappyVersionLockFileExist(projectRoot) {
-		return true, nil
+		return true, "", "", nil
 	}
 
 	happyVersionLock, err := config.LoadHappyVersionLockFile(projectRoot)
 	if err != nil {
-		return false, err
+		return false, "", "", err
 	}
 
 	if util.GetVersion().Version != happyVersionLock.HappyVersion {
-		return false, nil
+		return false, util.GetVersion().Version, happyVersionLock.HappyVersion, nil
 	}
 
-	return true, nil
+	return true, util.GetVersion().Version, happyVersionLock.HappyVersion, nil
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -7,6 +7,7 @@ import (
 	"github.com/chanzuckerberg/happy/cli/pkg/hapi"
 	"github.com/chanzuckerberg/happy/shared/model"
 	"github.com/chanzuckerberg/happy/shared/util"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -71,4 +72,20 @@ func IsHappyOutdated(cmd *cobra.Command) (bool, *util.Release, *util.Release, er
 	}
 
 	return !cliVersion.Equal(latestAvailableVersion), cliVersion, latestAvailableVersion, nil
+}
+
+func WarnIfHappyOutdated(cmd *cobra.Command) {
+
+	outdated, cliVersion, latestAvailableVersion, err := IsHappyOutdated(cmd)
+
+	if err != nil {
+		log.Errorf("Error checking for latest available version number: %v", err)
+		return
+	}
+
+	if outdated {
+		log.Warnf("This copy of Happy CLI is not the latest available. CLI version: %s  Latest available version: %s\n", cliVersion.Version, latestAvailableVersion.Version)
+		log.Warn("To update on Mac, run:  brew upgrade happy")
+	}
+
 }

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -201,7 +201,7 @@ func CheckLockedHappyVersion(cmd *cobra.Command) error {
 			return nil
 		} 
 			if !versionMatch {
-				return errors.Errorf("Installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
+				return errors.Errorf("installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
 			
 		}
 	}

--- a/cli/pkg/config/happy_version_lock.go
+++ b/cli/pkg/config/happy_version_lock.go
@@ -80,8 +80,7 @@ func (v *HappyVersionLockFile) Save() error {
 }
 
 func calcHappyVersionPath(projectRoot string) string {
-	versionFilePath := filepath.Join(projectRoot, ".happy", "version.lock")
-	return versionFilePath
+	return filepath.Join(projectRoot, ".happy", "version.lock")
 }
 
 func (v *HappyVersionLockFile) SetVersion(version string) error {

--- a/cli/pkg/config/happy_version_lock.go
+++ b/cli/pkg/config/happy_version_lock.go
@@ -24,6 +24,12 @@ func NewHappyVersionLockFile(projectRoot string) *HappyVersionLockFile {
 	}
 }
 
+func DoesHappyVersionLockFileExist(projectRoot string) bool {
+	filePath := calcHappyVersionPath(projectRoot)
+	_, err := os.Stat(filePath)
+	return err == nil
+}
+
 func LoadHappyVersionLockFile(projectRoot string) (*HappyVersionLockFile, error) {
 
 	filePath := calcHappyVersionPath(projectRoot)

--- a/cli/pkg/config/happy_version_lock.go
+++ b/cli/pkg/config/happy_version_lock.go
@@ -45,20 +45,20 @@ func LoadHappyVersionLockFile(projectRoot string) (*HappyVersionLockFile, error)
 
 	versionFile, err := os.Open(filePath)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to open happy version lock file")
 	}
 	defer versionFile.Close()
 
 	contents, err := ioutil.ReadAll(versionFile)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to read happy version lock file")
 	}
 
 	hvlf := HappyVersionLockFile{}
 
 	err = json.Unmarshal(contents, &hvlf)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error parsing happy version lock file")
 	}
 
 	return &hvlf, nil
@@ -78,7 +78,7 @@ func (v *HappyVersionLockFile) Save() error {
 
 	contents, err := json.MarshalIndent(&v, "", " ")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not marshal config file contents")
 	}
 
 	happyVersionFile.WriteString(string(contents))

--- a/cli/pkg/config/happy_version_lock.go
+++ b/cli/pkg/config/happy_version_lock.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+type HappyVersionLockFile struct {
+	HappyVersion string
+	path         string
+}
+
+func NewHappyVersionLockFile(projectRoot string) *HappyVersionLockFile {
+	path := calcHappyVersionPath(projectRoot)
+
+	return &HappyVersionLockFile{
+		HappyVersion: "",
+		path:         path,
+	}
+}
+
+func LoadHappyVersionLockFile(projectRoot string) (*HappyVersionLockFile, error) {
+	return NewHappyVersionLockFile(projectRoot), nil
+}
+
+func (v *HappyVersionLockFile) Save() error {
+
+	path, err := v.GetPath()
+	if err != nil {
+		return err
+	}
+
+	happyVersionFile, err := os.Create(path)
+
+	if err != nil {
+		return errors.New(fmt.Sprintf("Could not create %s: %v", v.path, err))
+	}
+
+	happyVersionFile.WriteString(v.HappyVersion)
+	happyVersionFile.Close()
+
+	return nil
+}
+
+func calcHappyVersionPath(projectRoot string) string {
+	versionFilePath := filepath.Join(projectRoot, ".happy", "version.lock")
+	return versionFilePath
+}
+
+func (v *HappyVersionLockFile) SetVersion(version string) error {
+
+	if version == "" {
+		return errors.New("Empty version is not allowed")
+	}
+
+	v.HappyVersion = version
+
+	return nil
+}
+
+func (v *HappyVersionLockFile) GetVersion() (string, error) {
+
+	if v.HappyVersion == "" {
+		return "", errors.New("Version is not set")
+	}
+
+	return v.HappyVersion, nil
+}
+
+func (v *HappyVersionLockFile) GetPath() (string, error) {
+	if v.path == "" {
+		return "", errors.New("Path is not set")
+	}
+	return v.path, nil
+}

--- a/cli/pkg/config/happy_version_lock.go
+++ b/cli/pkg/config/happy_version_lock.go
@@ -12,16 +12,25 @@ import (
 
 type HappyVersionLockFile struct {
 	HappyVersion string
-	path         string
+	Path         string
 }
 
-func NewHappyVersionLockFile(projectRoot string) *HappyVersionLockFile {
+func NewHappyVersionLockFile(projectRoot string, requiredVersion string) (*HappyVersionLockFile, error) {
+
+	if projectRoot == "" {
+		return nil, errors.New("No projectRoot specified")
+	}
+
+	if requiredVersion == "" {
+		return nil, errors.New("No requiredVersion specified")
+	}
+
 	path := calcHappyVersionPath(projectRoot)
 
 	return &HappyVersionLockFile{
-		HappyVersion: "",
-		path:         path,
-	}
+		HappyVersion: requiredVersion,
+		Path:         path,
+	}, nil
 }
 
 func DoesHappyVersionLockFileExist(projectRoot string) bool {
@@ -57,15 +66,14 @@ func LoadHappyVersionLockFile(projectRoot string) (*HappyVersionLockFile, error)
 
 func (v *HappyVersionLockFile) Save() error {
 
-	path, err := v.GetPath()
-	if err != nil {
-		return err
+	if v.Path == "" {
+		return errors.New("Path is not set!")
 	}
 
-	happyVersionFile, err := os.Create(path)
+	happyVersionFile, err := os.Create(v.Path)
 
 	if err != nil {
-		return errors.New(fmt.Sprintf("Could not create %s: %v", v.path, err))
+		return errors.New(fmt.Sprintf("Could not create %s: %v", v.Path, err))
 	}
 
 	contents, err := json.MarshalIndent(&v, "", " ")
@@ -81,31 +89,4 @@ func (v *HappyVersionLockFile) Save() error {
 
 func calcHappyVersionPath(projectRoot string) string {
 	return filepath.Join(projectRoot, ".happy", "version.lock")
-}
-
-func (v *HappyVersionLockFile) SetVersion(version string) error {
-
-	if version == "" {
-		return errors.New("Empty version is not allowed")
-	}
-
-	v.HappyVersion = version
-
-	return nil
-}
-
-func (v *HappyVersionLockFile) GetVersion() (string, error) {
-
-	if v.HappyVersion == "" {
-		return "", errors.New("Version is not set")
-	}
-
-	return v.HappyVersion, nil
-}
-
-func (v *HappyVersionLockFile) GetPath() (string, error) {
-	if v.path == "" {
-		return "", errors.New("Path is not set")
-	}
-	return v.path, nil
 }

--- a/cli/pkg/config/happy_version_lock.go
+++ b/cli/pkg/config/happy_version_lock.go
@@ -12,7 +12,7 @@ import (
 
 type HappyVersionLockFile struct {
 	HappyVersion string
-	Path         string
+	Path         string `json:"-"`
 }
 
 func NewHappyVersionLockFile(projectRoot string, requiredVersion string) (*HappyVersionLockFile, error) {


### PR DESCRIPTION
Implement (currently optional) Happy version locking in repos.

Scenarios:

- Fail check silently and proceed if we can't get the latest available version (generally if we are outside a project root)
- Allow for version, available-version, and set-lock commands to exclude locked version check
- Allow for legacy behavior if no lockfile is present (i.e. proceed with any version)
- Refuse to run for most commands if lockfile is present and version does not match