### PR TITLE
feat: use aws_iam_role_policy_attachment resource to allow multiple polices per role

### DIFF
--- a/terraform/modules/happy-iam-service-account-eks/README.md
+++ b/terraform/modules/happy-iam-service-account-eks/README.md
@@ -23,8 +23,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy_attachment.attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [kubernetes_service_account.service_account](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [aws_iam_policy_document.assume-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/terraform/modules/happy-iam-service-account-eks/main.tf
+++ b/terraform/modules/happy-iam-service-account-eks/main.tf
@@ -50,8 +50,7 @@ resource "aws_iam_policy" "policy" {
   tags        = var.tags
 }
 
-resource "aws_iam_policy_attachment" "attach" {
-  name       = aws_iam_role.role.name
-  roles      = [aws_iam_role.role.name]
+resource "aws_iam_role_policy_attachment" "attach" {
+  role       = aws_iam_role.role.name
   policy_arn = aws_iam_policy.policy.arn
 }


### PR DESCRIPTION
### Summary
We want to be able to attach multiple policies to the service role. Per the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment), using an iam_policy_attachment resource creates an exclusive attachment of iam policies.
> The aws_iam_policy_attachment resource creates exclusive attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource. This means that even any users/roles/groups that have the attached policy via any other mechanism (including other Terraform resources) will have that attached policy revoked by this resource. Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead. These resources do not enforce exclusive attachment of an IAM policy.