### PR TITLE
feat: CDI-1356 - add database creds to output

### DIFF
--- a/terraform/modules/happy-env-eks/README.md
+++ b/terraform/modules/happy-env-eks/README.md
@@ -73,6 +73,7 @@ https://docs.google.com/drawings/d/1AsJts2qCmw7685A6WZPDb5ApkXyuPRc27Lg3zzWuPaA/
 | Name | Description |
 |------|-------------|
 | <a name="output_dashboard"></a> [dashboard](#output\_dashboard) | n/a |
+| <a name="output_databases"></a> [databases](#output\_databases) | n/a |
 | <a name="output_integration_secret"></a> [integration\_secret](#output\_integration\_secret) | n/a |
 | <a name="output_namespace"></a> [namespace](#output\_namespace) | n/a |
 | <a name="output_panther_waf_configuration"></a> [panther\_waf\_configuration](#output\_panther\_waf\_configuration) | Outputs that help Security Eng team configure Panther monitoring |

--- a/terraform/modules/happy-env-eks/outputs.tf
+++ b/terraform/modules/happy-env-eks/outputs.tf
@@ -23,3 +23,13 @@ output "panther_waf_configuration" {
   sensitive   = false
   description = "Outputs that help Security Eng team configure Panther monitoring"
 }
+
+output "databases" {
+  value = { for k, v in dbs: k => {
+    database_host = v.database_host
+    database_name = v.database_name
+    database_username = v.database_username
+    database_password = v.database_password
+  }}
+  sensitive = true
+}

--- a/terraform/modules/happy-env-eks/outputs.tf
+++ b/terraform/modules/happy-env-eks/outputs.tf
@@ -25,11 +25,11 @@ output "panther_waf_configuration" {
 }
 
 output "databases" {
-  value = { for k, v in dbs: k => {
-    database_host = v.database_host
-    database_name = v.database_name
+  value = { for k, v in dbs : k => {
+    database_host     = v.database_host
+    database_name     = v.database_name
     database_username = v.database_username
     database_password = v.database_password
-  }}
+  } }
   sensitive = true
 }


### PR DESCRIPTION
This will allow us to pull in this output for setting up debezium connectors (which need to connect to these RDSs) without manually copying them into SSM