### PR TITLE
chore: Always create iam service role

### DIFF
--- a/terraform/modules/happy-service-eks/iam.tf
+++ b/terraform/modules/happy-service-eks/iam.tf
@@ -1,5 +1,4 @@
 module "iam_service_account" {
-  count  = var.aws_iam_policy_json == "" ? 0 : 1
   source = "../happy-iam-service-account-eks"
 
   eks_cluster         = var.eks_cluster


### PR DESCRIPTION
### Summary
A service role isn't created unless the policy json is not empty. We'd like to be able to attach policies on the role outside of the `aws_iam_policy_json` field. It'd be helpful if this role was always created