### PR TITLE
fix: workspaces with no state will not have info

### DIFF
--- a/shared/workspace_repo/workspace.go
+++ b/shared/workspace_repo/workspace.go
@@ -584,9 +584,14 @@ func (s *TFEWorkspace) GetResources(ctx context.Context) ([]util.ManagedResource
 }
 
 func (s *TFEWorkspace) GetCurrentRunStatus(ctx context.Context) string {
+	state, err := s.HasState(ctx)
+	if err != nil || !state {
+		return "no-state"
+	}
 	if s.currentRun == nil {
 		currentRun, err := s.tfc.Runs.Read(ctx, s.workspace.CurrentRun.ID)
 		if err != nil {
+			logrus.Errorf("failed to get current run for workspace %s", s.WorkspaceName())
 			return ""
 		}
 		s.currentRun = currentRun
@@ -595,6 +600,11 @@ func (s *TFEWorkspace) GetCurrentRunStatus(ctx context.Context) string {
 }
 
 func (s *TFEWorkspace) GetCurrentRunUrl(ctx context.Context) string {
+	state, err := s.HasState(ctx)
+	if err != nil || !state {
+		return s.GetWorkspaceUrl()
+	}
+
 	return fmt.Sprintf("%s/runs/%s", s.GetWorkspaceUrl(), s.GetCurrentRunID())
 }
 
@@ -627,16 +637,23 @@ func (s *TFEWorkspace) GetWorkspaceUrl() string {
 
 func (s *TFEWorkspace) GetEndpoints(ctx context.Context) (map[string]string, error) {
 	endpoints := map[string]string{}
+	state, err := s.HasState(ctx)
+	if err != nil {
+		return endpoints, errors.Wrap(err, "unable to check if workspace had state")
+	}
+	if !state {
+		return endpoints, nil
+	}
 	outputs, err := s.GetOutputs(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get workspace outputs")
+		return endpoints, errors.Wrap(err, "unable to get workspace outputs")
 	}
 	if endpoint, ok := outputs["frontend_url"]; ok {
 		endpoints["FRONTEND"] = endpoint
 	} else if svc_endpoints, ok := outputs["service_urls"]; ok {
 		err := json.Unmarshal([]byte(svc_endpoints), &endpoints)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to decode endpoints")
+			return endpoints, errors.Wrap(err, "unable to decode endpoints")
 		}
 	}
 	return endpoints, nil

--- a/shared/workspace_repo/workspace_test.go
+++ b/shared/workspace_repo/workspace_test.go
@@ -146,7 +146,7 @@ func TestWorkspace(t *testing.T) {
 	req.NoError(err)
 
 	status := workspace.GetCurrentRunStatus(ctx)
-	req.Equal("applied", status)
+	req.Equal("no-state", status)
 	err = workspace.SetVars(ctx, "happy/app", "happy-app", "description", false)
 	req.NoError(err)
 	err = workspace.SetVars(ctx, "happy/app1", "happy-app", "description", false)


### PR DESCRIPTION
This PR fixes an issue in the API where if the TFE workspace doesn't have any state (as in, there have been no applies or if there was an error on their first apply), the state information is not populated. This leads to a nil pointer exception. This PR handles this by always checking for state and returning empty information if no state.