### PR TITLE
fix: Service port is not populated

### DIFF
--- a/terraform/modules/happy-stack-eks/main.tf
+++ b/terraform/modules/happy-stack-eks/main.tf
@@ -35,7 +35,7 @@ locals {
     host_match          = var.routing_method == "CONTEXT" ? v.stack_host_match : v.service_host_match
     group_name          = var.routing_method == "CONTEXT" ? "stack-${var.stack_name}-${local.suffix}" : "service-${var.stack_name}-${k}-${local.suffix}"
     service_name        = "${var.stack_name}-${k}"
-    service_port = coalesce(v.service_port, v.port)
+    service_port        = coalesce(v.service_port, v.port)
     bypasses = (v.service_type == "INTERNAL" ?
       merge({
         // by default, add an options bypass since this is used a lot by developers out of the gate

--- a/terraform/modules/happy-stack-eks/main.tf
+++ b/terraform/modules/happy-stack-eks/main.tf
@@ -35,6 +35,7 @@ locals {
     host_match          = var.routing_method == "CONTEXT" ? v.stack_host_match : v.service_host_match
     group_name          = var.routing_method == "CONTEXT" ? "stack-${var.stack_name}-${local.suffix}" : "service-${var.stack_name}-${k}-${local.suffix}"
     service_name        = "${var.stack_name}-${k}"
+    service_port = coalesce(v.service_port, v.port)
     bypasses = (v.service_type == "INTERNAL" ?
       merge({
         // by default, add an options bypass since this is used a lot by developers out of the gate


### PR DESCRIPTION
This PR addresses the following issue:
```
╷
│ Error: Invalid template interpolation value
│ 
│   on .terraform/modules/stack/terraform/modules/happy-stack-eks/main.tf line 84, in locals:
│   84:       "PRIVATE_${upper(replace(k, "-", "_"))}_ENDPOINT" = "${lower(v.service_scheme)}://${v.service_name}.${var.k8s_namespace}.svc.cluster.local:${v.service_port}"
│     ├────────────────
│     │ v.service_port is null
│ 
│ The expression result is null. Cannot include a null value in a string
│ template.
```