### PR TITLE
fix: aws provider 5.0 deprecated source_json

### DIFF
--- a/terraform/modules/happy-env-ecs/README.md
+++ b/terraform/modules/happy-env-ecs/README.md
@@ -31,7 +31,7 @@ Default happy path environment module that supports creating S3 buckets, RDS dat
 | <a name="module_happy_service_account"></a> [happy\_service\_account](#module\_happy\_service\_account) | ../happy-tfe-okta-service-account | n/a |
 | <a name="module_instance-cloud-init-script"></a> [instance-cloud-init-script](#module\_instance-cloud-init-script) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/instance-cloud-init-script | v0.227.0 |
 | <a name="module_integration_secret_reader_policy"></a> [integration\_secret\_reader\_policy](#module\_integration\_secret\_reader\_policy) | git@github.com:chanzuckerberg/cztack//aws-iam-secrets-reader-policy | v0.43.3 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | github.com/chanzuckerberg/cztack//aws-s3-private-bucket | v0.43.1 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | github.com/chanzuckerberg/cztack//aws-s3-private-bucket | v0.56.1 |
 | <a name="module_swipe"></a> [swipe](#module\_swipe) | git@github.com:chanzuckerberg/swipe | v1.2.1 |
 
 ## Resources

--- a/terraform/modules/happy-env-ecs/s3.tf
+++ b/terraform/modules/happy-env-ecs/s3.tf
@@ -1,6 +1,6 @@
 module "s3_bucket" {
   for_each          = var.s3_buckets
-  source            = "github.com/chanzuckerberg/cztack//aws-s3-private-bucket?ref=v0.43.1"
+  source            = "github.com/chanzuckerberg/cztack//aws-s3-private-bucket?ref=v0.56.1"
   project           = var.tags["project"]
   env               = var.tags["env"]
   service           = "happy"

--- a/terraform/modules/happy-env-eks/README.md
+++ b/terraform/modules/happy-env-eks/README.md
@@ -26,7 +26,7 @@ https://docs.google.com/drawings/d/1AsJts2qCmw7685A6WZPDb5ApkXyuPRc27Lg3zzWuPaA/
 |------|--------|---------|
 | <a name="module_cert"></a> [cert](#module\_cert) | github.com/chanzuckerberg/cztack//aws-acm-certificate | v0.43.1 |
 | <a name="module_dbs"></a> [dbs](#module\_dbs) | github.com/chanzuckerberg/cztack//aws-aurora-postgres | v0.49.0 |
-| <a name="module_ecrs"></a> [ecrs](#module\_ecrs) | git@github.com:chanzuckerberg/cztack//aws-ecr-repo | v0.54.0 |
+| <a name="module_ecrs"></a> [ecrs](#module\_ecrs) | git@github.com:chanzuckerberg/cztack//aws-ecr-repo | v0.56.0 |
 | <a name="module_happy_github_ci_role"></a> [happy\_github\_ci\_role](#module\_happy\_github\_ci\_role) | ../happy-github-ci-role | n/a |
 | <a name="module_happy_okta_app"></a> [happy\_okta\_app](#module\_happy\_okta\_app) | ../happy-tfe-okta-app | n/a |
 | <a name="module_happy_service_account"></a> [happy\_service\_account](#module\_happy\_service\_account) | ../happy-tfe-okta-service-account | n/a |

--- a/terraform/modules/happy-env-eks/README.md
+++ b/terraform/modules/happy-env-eks/README.md
@@ -32,7 +32,7 @@ https://docs.google.com/drawings/d/1AsJts2qCmw7685A6WZPDb5ApkXyuPRc27Lg3zzWuPaA/
 | <a name="module_happy_service_account"></a> [happy\_service\_account](#module\_happy\_service\_account) | ../happy-tfe-okta-service-account | n/a |
 | <a name="module_ops-genie"></a> [ops-genie](#module\_ops-genie) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ops-genie-service | main |
 | <a name="module_regional-waf"></a> [regional-waf](#module\_regional-waf) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/web-acl-regional | web-acl-regional-v1.2.4 |
-| <a name="module_s3_buckets"></a> [s3\_buckets](#module\_s3\_buckets) | github.com/chanzuckerberg/cztack//aws-s3-private-bucket | v0.43.1 |
+| <a name="module_s3_buckets"></a> [s3\_buckets](#module\_s3\_buckets) | github.com/chanzuckerberg/cztack//aws-s3-private-bucket | v0.56.1 |
 
 ## Resources
 

--- a/terraform/modules/happy-env-eks/ecr.tf
+++ b/terraform/modules/happy-env-eks/ecr.tf
@@ -1,7 +1,7 @@
 
 module "ecrs" {
   for_each = var.ecr_repos
-  source   = "git@github.com:chanzuckerberg/cztack//aws-ecr-repo?ref=v0.56.0"
+  source   = "git@github.com:chanzuckerberg/cztack//aws-ecr-repo?ref=v0.56.1"
 
   name       = each.value["name"]
   read_arns  = each.value["read_arns"]

--- a/terraform/modules/happy-env-eks/ecr.tf
+++ b/terraform/modules/happy-env-eks/ecr.tf
@@ -1,7 +1,7 @@
 
 module "ecrs" {
   for_each = var.ecr_repos
-  source   = "git@github.com:chanzuckerberg/cztack//aws-ecr-repo?ref=v0.54.0"
+  source   = "git@github.com:chanzuckerberg/cztack//aws-ecr-repo?ref=v0.56.0"
 
   name       = each.value["name"]
   read_arns  = each.value["read_arns"]

--- a/terraform/modules/happy-env-eks/s3.tf
+++ b/terraform/modules/happy-env-eks/s3.tf
@@ -1,6 +1,6 @@
 module "s3_buckets" {
   for_each          = var.s3_buckets
-  source            = "github.com/chanzuckerberg/cztack//aws-s3-private-bucket?ref=v0.43.1"
+  source            = "github.com/chanzuckerberg/cztack//aws-s3-private-bucket?ref=v0.56.1"
   project           = var.tags["project"]
   env               = var.tags["env"]
   service           = "happy"

--- a/terraform/modules/happy-service-eks/README.md
+++ b/terraform/modules/happy-service-eks/README.md
@@ -20,7 +20,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecr"></a> [ecr](#module\_ecr) | git@github.com:chanzuckerberg/cztack//aws-ecr-repo | v0.53.1 |
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | git@github.com:chanzuckerberg/cztack//aws-ecr-repo | v0.56.0 |
 | <a name="module_iam_service_account"></a> [iam\_service\_account](#module\_iam\_service\_account) | ../happy-iam-service-account-eks | n/a |
 | <a name="module_ingress"></a> [ingress](#module\_ingress) | ../happy-ingress-eks | n/a |
 

--- a/terraform/modules/happy-service-eks/ecr.tf
+++ b/terraform/modules/happy-service-eks/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr" {
-  source = "git@github.com:chanzuckerberg/cztack//aws-ecr-repo?ref=v0.56.0"
+  source = "git@github.com:chanzuckerberg/cztack//aws-ecr-repo?ref=v0.56.1"
 
   name         = "${var.stack_name}/${local.tags.env}/${var.container_name}"
   force_delete = true

--- a/terraform/modules/happy-service-eks/ecr.tf
+++ b/terraform/modules/happy-service-eks/ecr.tf
@@ -1,5 +1,5 @@
 module "ecr" {
-  source = "git@github.com:chanzuckerberg/cztack//aws-ecr-repo?ref=v0.53.1"
+  source = "git@github.com:chanzuckerberg/cztack//aws-ecr-repo?ref=v0.56.0"
 
   name         = "${var.stack_name}/${local.tags.env}/${var.container_name}"
   force_delete = true


### PR DESCRIPTION
See https://github.com/chanzuckerberg/cztack/pull/494 for additional details. This PR is to fix the following error:

```
│ Error: Unsupported argument
│ 
│   on .terraform/modules/stack.services.ecr/aws-ecr-repo/main.tf line 99, in data "aws_iam_policy_document" "policy":
│   99:   source_json = var.ecr_resource_policy
│ 
│ An argument named "source_json" is not expected here.
```

Customer impact: https://chanzuckerbergteam.slack.com/archives/C01C310V70X/p1685041757045689 and https://chanzuckerbergteam.slack.com/archives/C04NVSCDFR7/p1685133258183989