### PR TITLE
fix: can't use persistenprerun

### DIFF
--- a/cli/cmd/build.go
+++ b/cli/cmd/build.go
@@ -20,7 +20,7 @@ var buildCmd = &cobra.Command{
 	Short:        "Build docker images",
 	Long:         "Build docker images using docker compose",
 	SilenceUsage: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		checklist := util.NewValidationCheckList()
 		return util.ValidateEnvironment(cmd.Context(),
 			checklist.DockerEngineRunning,

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -79,7 +79,7 @@ var configCmd = &cobra.Command{
 	Short:        "modify app configs",
 	Long:         "Create, Read, Update, and Delete app configs for environment '{env}'",
 	SilenceUsage: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		err := ValidateConfigFeature(cmd, args)
 		if err != nil {
 			return err

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -48,17 +48,18 @@ var createCmd = &cobra.Command{
 		happyCmd.IsTagUsedWithSkipTag,
 		cobra.ExactArgs(1),
 		happyCmd.IsStackNameDNSCharset,
-		happyCmd.IsStackNameAlphaNumeric),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.DockerEngineRunning,
-			checklist.MinDockerComposeVersion,
-			checklist.DockerInstalled,
-			checklist.TerraformInstalled,
-			checklist.AwsInstalled,
-		)
-	},
+		happyCmd.IsStackNameAlphaNumeric,
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.DockerEngineRunning,
+				checklist.MinDockerComposeVersion,
+				checklist.DockerInstalled,
+				checklist.TerraformInstalled,
+				checklist.AwsInstalled,
+			)
+		},
+	),
 	RunE: runCreate,
 }
 

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -1,1 +1,0 @@
-package cmd

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -35,13 +35,14 @@ var deleteCmd = &cobra.Command{
 	PreRunE: happyCmd.Validate(
 		cobra.ExactArgs(1),
 		happyCmd.IsStackNameDNSCharset,
-		happyCmd.IsStackNameAlphaNumeric),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.TerraformInstalled,
-		)
-	},
+		happyCmd.IsStackNameAlphaNumeric,
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.TerraformInstalled,
+			)
+		},
+	),
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -29,17 +29,19 @@ var deployCmd = &cobra.Command{
 	Short:        "Get a git sha of last successful deployment",
 	Long:         "Get a git sha of the last successful deployment to a selected environment",
 	SilenceUsage: true,
-	PreRunE:      cmd.Validate(cobra.ExactArgs(1)),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.DockerEngineRunning,
-			checklist.MinDockerComposeVersion,
-			checklist.DockerInstalled,
-			checklist.TerraformInstalled,
-			checklist.AwsInstalled,
-		)
-	},
+	PreRunE: cmd.Validate(
+		cobra.ExactArgs(1),
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.DockerEngineRunning,
+				checklist.MinDockerComposeVersion,
+				checklist.DockerInstalled,
+				checklist.TerraformInstalled,
+				checklist.AwsInstalled,
+			)
+		},
+	),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 

--- a/cli/cmd/events.go
+++ b/cli/cmd/events.go
@@ -17,18 +17,20 @@ func init() {
 }
 
 var eventsCmd = &cobra.Command{
-	Use:          "events",
-	Short:        "Show stack events",
-	Long:         "Showing stack events in environment '{env}'",
-	PreRunE:      cmd.Validate(cobra.ExactArgs(1)),
+	Use:   "events",
+	Short: "Show stack events",
+	Long:  "Showing stack events in environment '{env}'",
+	PreRunE: cmd.Validate(
+		cobra.ExactArgs(1),
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.TerraformInstalled,
+				checklist.AwsInstalled,
+			)
+		},
+	),
 	SilenceUsage: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.TerraformInstalled,
-			checklist.AwsInstalled,
-		)
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		stackName := args[0]

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -25,14 +25,16 @@ var getCmd = &cobra.Command{
 	Short:        "Get stack",
 	Long:         "Get a stack in environment '{env}'",
 	SilenceUsage: true,
-	PreRunE:      cmd.Validate(cobra.ExactArgs(1)),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.TerraformInstalled,
-			checklist.AwsInstalled,
-		)
-	},
+	PreRunE: cmd.Validate(
+		cobra.ExactArgs(1),
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.TerraformInstalled,
+				checklist.AwsInstalled,
+			)
+		},
+	),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		stackName := args[0]

--- a/cli/cmd/infra.go
+++ b/cli/cmd/infra.go
@@ -17,7 +17,7 @@ var infraCmd = &cobra.Command{
 	Short:        "Infra commands",
 	Long:         "Execute infra commands in environment '{env}'",
 	SilenceUsage: false,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		checklist := util.NewValidationCheckList()
 		return util.ValidateEnvironment(cmd.Context(),
 			checklist.TerraformInstalled,

--- a/cli/cmd/infra_generate.go
+++ b/cli/cmd/infra_generate.go
@@ -18,7 +18,7 @@ var infraGenerateCmd = &cobra.Command{
 	Short:        "Generate Happy Stack HCL code",
 	Long:         "Generate Happy Stack HCL code in environment '{env}'",
 	SilenceUsage: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		checklist := util.NewValidationCheckList()
 		return util.ValidateEnvironment(cmd.Context(),
 			checklist.TerraformInstalled,

--- a/cli/cmd/infra_ingest.go
+++ b/cli/cmd/infra_ingest.go
@@ -18,7 +18,7 @@ var infraIngestCmd = &cobra.Command{
 	Short:        "Ingest Happy Stack HCL code",
 	Long:         "Ingest Happy Stack HCL code from all environments",
 	SilenceUsage: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		checklist := util.NewValidationCheckList()
 		return util.ValidateEnvironment(cmd.Context(),
 			checklist.TerraformInstalled,

--- a/cli/cmd/infra_validate.go
+++ b/cli/cmd/infra_validate.go
@@ -18,7 +18,7 @@ var infraValidateCmd = &cobra.Command{
 	Short:        "Validate Happy Stack HCL code",
 	Long:         "Validate Happy Stack HCL code for all environments",
 	SilenceUsage: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		checklist := util.NewValidationCheckList()
 		return util.ValidateEnvironment(cmd.Context(),
 			checklist.TerraformInstalled,

--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -31,7 +31,7 @@ var listCmd = &cobra.Command{
 	Short:        "List stacks",
 	Long:         "Listing stacks in environment '{env}'",
 	SilenceUsage: true,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		checklist := util.NewValidationCheckList()
 		return util.ValidateEnvironment(cmd.Context(),
 			checklist.TerraformInstalled,

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -35,14 +35,17 @@ var logsCmd = &cobra.Command{
 	Long:         "Print the logs of a service (frontend, backend, upload, migrations)",
 	SilenceUsage: true,
 	RunE:         runLogs,
-	PreRunE:      cmd.Validate(cobra.ExactArgs(2), cmd.IsStackNameDNSCharset),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.TerraformInstalled,
-			checklist.AwsInstalled,
-		)
-	},
+	PreRunE: cmd.Validate(
+		cobra.ExactArgs(2),
+		cmd.IsStackNameDNSCharset,
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.TerraformInstalled,
+				checklist.AwsInstalled,
+			)
+		},
+	),
 }
 
 func runLogs(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/migrate.go
+++ b/cli/cmd/migrate.go
@@ -25,7 +25,10 @@ var migrateCmd = &cobra.Command{
 	Short:        "Migrate stack",
 	Long:         "Run migration tasks for stack with given name",
 	SilenceUsage: true,
-	PreRunE:      cmd.Validate(cobra.ExactArgs(1), cmd.IsStackNameDNSCharset),
+	PreRunE: cmd.Validate(
+		cobra.ExactArgs(1),
+		cmd.IsStackNameDNSCharset,
+	),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
 		return runMigrate(cmd, stackName)

--- a/cli/cmd/push.go
+++ b/cli/cmd/push.go
@@ -28,17 +28,18 @@ var pushCmd = &cobra.Command{
 	PreRunE: happyCmd.Validate(
 		cobra.ExactArgs(1),
 		happyCmd.IsStackNameDNSCharset,
-		happyCmd.IsStackNameAlphaNumeric),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.DockerEngineRunning,
-			checklist.MinDockerComposeVersion,
-			checklist.DockerInstalled,
-			checklist.TerraformInstalled,
-			checklist.AwsInstalled,
-		)
-	},
+		happyCmd.IsStackNameAlphaNumeric,
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.DockerEngineRunning,
+				checklist.MinDockerComposeVersion,
+				checklist.DockerInstalled,
+				checklist.TerraformInstalled,
+				checklist.AwsInstalled,
+			)
+		},
+	),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
 		happyClient, err := makeHappyClient(cmd, sliceName, stackName, tags, createTag)

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -24,14 +24,16 @@ var resourcesCmd = &cobra.Command{
 	Short:        "Get stack resources",
 	Long:         "Get stack resources in environment '{env}'",
 	SilenceUsage: true,
-	PreRunE:      cmd.Validate(cobra.ExactArgs(1)),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.TerraformInstalled,
-			checklist.AwsInstalled,
-		)
-	},
+	PreRunE: cmd.Validate(
+		cobra.ExactArgs(1),
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.TerraformInstalled,
+				checklist.AwsInstalled,
+			)
+		},
+	),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		stackName := args[0]

--- a/cli/cmd/shell.go
+++ b/cli/cmd/shell.go
@@ -20,14 +20,17 @@ var shellCmd = &cobra.Command{
 	Short:        "Execute into a container",
 	Long:         "Execute into a running service task container",
 	SilenceUsage: true,
-	PreRunE:      cmd.Validate(cobra.ExactArgs(2), cmd.IsStackNameDNSCharset),
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.AwsInstalled,
-			checklist.AwsSessionManagerPluginInstalled,
-		)
-	},
+	PreRunE: cmd.Validate(
+		cobra.ExactArgs(2),
+		cmd.IsStackNameDNSCharset,
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.AwsInstalled,
+				checklist.AwsSessionManagerPluginInstalled,
+			)
+		},
+	),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 

--- a/cli/cmd/tags.go
+++ b/cli/cmd/tags.go
@@ -29,16 +29,17 @@ var tagsCmd = &cobra.Command{
 	Long:         "Add additional tags to already-pushed images in the ECR repo",
 	SilenceUsage: true,
 	RunE:         runTags,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.AwsInstalled,
-		)
-	},
 	PreRunE: happyCmd.Validate(
 		cobra.ExactArgs(1),
 		happyCmd.IsStackNameDNSCharset,
-		happyCmd.IsStackNameAlphaNumeric),
+		happyCmd.IsStackNameAlphaNumeric,
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.AwsInstalled,
+			)
+		},
+	),
 }
 
 func runTags(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -38,22 +38,23 @@ var updateCmd = &cobra.Command{
 	Long:         "Update stack matching STACK_NAME",
 	SilenceUsage: true,
 	RunE:         runUpdate,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checklist := util.NewValidationCheckList()
-		return util.ValidateEnvironment(cmd.Context(),
-			checklist.DockerEngineRunning,
-			checklist.MinDockerComposeVersion,
-			checklist.DockerInstalled,
-			checklist.TerraformInstalled,
-			checklist.AwsInstalled,
-		)
-	},
 	PreRunE: happyCmd.Validate(
 		happyCmd.IsImageEnvUsedWithImageStack,
 		happyCmd.IsTagUsedWithSkipTag,
 		cobra.ExactArgs(1),
 		happyCmd.IsStackNameDNSCharset,
-		happyCmd.IsStackNameAlphaNumeric),
+		happyCmd.IsStackNameAlphaNumeric,
+		func(cmd *cobra.Command, args []string) error {
+			checklist := util.NewValidationCheckList()
+			return util.ValidateEnvironment(cmd.Context(),
+				checklist.DockerEngineRunning,
+				checklist.MinDockerComposeVersion,
+				checklist.DockerInstalled,
+				checklist.TerraformInstalled,
+				checklist.AwsInstalled,
+			)
+		},
+	),
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
PersistentPreRun was being overwritten by subcommands, not allowing our root command to have logic for all commands such as starting a worker pool or setting the verbosity.