### PR TITLE
feat: pass along additional labels to pods

### DIFF
--- a/terraform/modules/happy-service-eks/main.tf
+++ b/terraform/modules/happy-service-eks/main.tf
@@ -3,13 +3,13 @@ data "aws_region" "current" {}
 locals {
   tags_string  = join(",", [for key, val in local.routing_tags : "${key}=${val}"])
   service_type = var.routing.service_type == "PRIVATE" ? "ClusterIP" : "NodePort"
-  labels = {
+  labels = merge({
     app                            = var.routing.service_name
     "app.kubernetes.io/name"       = var.stack_name
     "app.kubernetes.io/component"  = var.routing.service_name
     "app.kubernetes.io/part-of"    = var.stack_name
     "app.kubernetes.io/managed-by" = "happy"
-  }
+  }, var.additional_pod_labels)
 }
 
 resource "kubernetes_deployment_v1" "deployment" {

--- a/terraform/modules/happy-service-eks/variables.tf
+++ b/terraform/modules/happy-service-eks/variables.tf
@@ -282,3 +282,9 @@ variable "regional_wafv2_arn" {
   description = "A WAF to protect the EKS Ingress if needed"
   default     = null
 }
+
+variable "additional_pod_labels" {
+  type        = map(string)
+  description = "Additional labels to add to the pods."
+  default     = {}
+}

--- a/terraform/modules/happy-stack-eks/main.tf
+++ b/terraform/modules/happy-stack-eks/main.tf
@@ -203,6 +203,7 @@ module "services" {
   additional_env_vars_from_secrets     = var.additional_env_vars_from_secrets
   additional_volumes_from_secrets      = var.additional_volumes_from_secrets
   additional_volumes_from_config_maps  = var.additional_volumes_from_config_maps
+  additional_pod_labels                = var.additional_pod_labels
 
   tags = local.secret["tags"]
 

--- a/terraform/modules/happy-stack-eks/variables.tf
+++ b/terraform/modules/happy-stack-eks/variables.tf
@@ -216,3 +216,9 @@ variable "create_dashboard" {
   description = "Create a dashboard for this stack"
   default     = false
 }
+
+variable "additional_pod_labels" {
+  type        = map(string)
+  description = "Additional labels to add to the pods."
+  default     = {}
+}


### PR DESCRIPTION
### Summary
Pass along additional labels to pods. Specifically, we'd like to use custom labels for fine grained control over our prometheus k8s scraper config https://aws-otel.github.io/docs/getting-started/advanced-prometheus-remote-write-configurations#additional-kuberneteseks-scraping-configurations

### Test Plan
Will test out on a happy stack in the examples folder