### PR TITLE
fix: deadlock in API by not starting worker pool

### DIFF
--- a/api/pkg/cmd/stack.go
+++ b/api/pkg/cmd/stack.go
@@ -60,6 +60,10 @@ func enrichStacklistMetadata(ctx context.Context, stacklist []string, payload mo
 		integrationSecret.Tfe.Url,
 		integrationSecret.Tfe.Org,
 	).WithTFEToken(setup.GetConfiguration().TFE.Token)
+	ctx, done := context.WithCancel(ctx)
+	defer done()
+	workspace_repo.StartTFCWorkerPool(ctx)
+
 	wg := sync.WaitGroup{}
 
 	stackInfos := make([]*model.AppStackResponse, len(stacklist))


### PR DESCRIPTION
The workspace information is gathered by goroutines, so the credential check is preferred by a single worker. However, the worker pool wasn't started in the API causing the channel to block and return 504 timeout errors on calls to the stacklist API.