### PR TITLE
feat: change SSM location to k8s secret

### DIFF
--- a/terraform/modules/happy-tfe-okta-service-account/ssm_writer.tf
+++ b/terraform/modules/happy-tfe-okta-service-account/ssm_writer.tf
@@ -1,18 +1,18 @@
 # write the oidc provider values that happy api needs to the hapi chamber service so they will be available to happy api
 locals {
-  param_suffix = replace("${var.tags.service}_${var.tags.env}_${var.tags.project}", "-", "_")
+  param_suffix = upper(replace("${var.tags.service}_${var.tags.env}_${var.tags.project}", "-", "_"))
 }
 
 module "params" {
   source  = "git@github.com:chanzuckerberg/cztack//aws-ssm-params-writer?ref=v0.53.2"
-  service = "hapi"
-  project = "happy"
+  service = "secrets-from-aws-param"
+  project = "hapi"
   # all happy environments (dev, staging, prod) will be utilizing the prod API
   env   = "prod"
   owner = var.tags.owner
 
   parameters = {
-    "oidc_provider_${local.param_suffix}" : "${okta_auth_server.auth_server.issuer}|${local.label}"
+    "OIDC_PROVIDER_${local.param_suffix}" : "${okta_auth_server.auth_server.issuer}|${local.label}"
   }
 
   providers = {


### PR DESCRIPTION
Happy API now is hosted on EKS, so we need to update the path these parameters land so they are picked up by SSM controller. Tested with eng-portal migration and it seems to work well.