### PR TITLE
fix: Tidy cli dependencies in integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -62,7 +62,9 @@ jobs:
             restore-keys: |
               ${{ runner.os }}-go-
         - name: Build CLI
-          run: go build -o happy
+          run: |
+            go mod tidy
+            go build -o happy
           working-directory: ./cli
         - name: List stacks
           run: ../../cli/happy --detached --aws-profile="" list --output json


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1601:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1601" title="CCIE-1601" target="_blank">CCIE-1601</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Integration test fails because dependencies need tidy</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Fixes [CCIE-1601]

[CCIE-1601]: https://czi-tech.atlassian.net/browse/CCIE-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ