### PR TITLE
fix: 'happy list --output json' returns an invalid value

### DIFF
--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -49,7 +49,7 @@ var listCmd = &cobra.Command{
 			return errors.Wrap(err, "unable to initialize the happy client")
 		}
 
-		var metas []*model.AppStackResponse
+		metas := []*model.AppStackResponse{}
 		if remote {
 			metas, err = listStacksRemote(cmd.Context(), listAll, happyClient)
 			if err != nil {


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1603:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1603" title="CCIE-1603" target="_blank">CCIE-1603</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>'happy list --output json'  returns an invalid value</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Fixes [CCIE-1603]; previously returned `null`, where an array is expected, when no matching stacks are found.

[CCIE-1603]: https://czi-tech.atlassian.net/browse/CCIE-1603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ