### PR TITLE
fix: Fix stack info retrieval from json output in integration test (.name got replaced by .stack)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -74,7 +74,7 @@ jobs:
           working-directory: ./examples/integration_test
         - name: List stacks
           run: |
-            MATCHING_STACK_COUNT=$(../../cli/happy --detached --aws-profile="" list --output json | jq '[.[] | select(.name=="integration-test")] | length')
+            MATCHING_STACK_COUNT=$(../../cli/happy --detached --aws-profile="" list --output json | jq '[.[] | select(.stack=="integration-test")] | length')
             if [ "$MATCHING_STACK_COUNT" != "0" ]; then
               echo "Expected 0 stacks, got $MATCHING_STACK_COUNT"
               exit 1
@@ -102,7 +102,7 @@ jobs:
           working-directory: ./examples/integration_test
         - name: List stacks
           run: |
-            MATCHING_STACK_COUNT=$(../../cli/happy --detached --aws-profile="" list --output json | jq '[.[] | select(.name=="integration-test")] | length')
+            MATCHING_STACK_COUNT=$(../../cli/happy --detached --aws-profile="" list --output json | jq '[.[] | select(.stack=="integration-test")] | length')
             if [ "$MATCHING_STACK_COUNT" != "1" ]; then
               echo "Expected 1 stack, got $MATCHING_STACK_COUNT"
               exit 1
@@ -133,7 +133,7 @@ jobs:
           working-directory: ./examples/integration_test
         - name: List stacks
           run: |
-            MATCHING_STACK_COUNT=$(../../cli/happy --detached --aws-profile="" list --output json | jq '[.[] | select(.name=="integration-test")] | length')
+            MATCHING_STACK_COUNT=$(../../cli/happy --detached --aws-profile="" list --output json | jq '[.[] | select(.stack=="integration-test")] | length')
             if [ "$MATCHING_STACK_COUNT" != "0" ]; then
               echo "Expected 0 stacks, got $MATCHING_STACK_COUNT"
               exit 1


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1603:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1603" title="CCIE-1603" target="_blank">CCIE-1603</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>'happy list --output json'  returns an invalid value</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Done</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Fixes [CCIE-1603]

[CCIE-1603]: https://czi-tech.atlassian.net/browse/CCIE-1603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ