### PR TITLE
fix: underscores in db parameter groups

### DIFF
--- a/terraform/modules/happy-env-eks/db.tf
+++ b/terraform/modules/happy-env-eks/db.tf
@@ -10,7 +10,10 @@ module "dbs" {
 
   project = var.tags.project
   env     = var.tags.env
-  service = "${var.tags.service}-${each.value["name"]}"
+  # some db names have underscores (this is fine)
+  # but the service is used as the name of other things like the parameter groups
+  # that do not allow underscores.
+  service = replace("${var.tags.service}-${each.value["name"]}", "_", "-")
   owner   = var.tags.owner
 
   database_name              = each.value["name"]


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1506:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1506" title="CCIE-1506" target="_blank">CCIE-1506</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Move eng-portal to EKS</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-1506