### PR TITLE
feat: automatically restart api when new happy env credentials are added

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -28,5 +28,7 @@ COPY --from=builder /code/api/app-config*.yaml .
 ENV CONFIG_YAML_DIRECTORY=./
 ENV TZ=utc
 
+RUN go install github.com/cespare/reflex@v0.3.1
 COPY ./entrypoint.sh .
+
 ENTRYPOINT ["./entrypoint.sh"]

--- a/api/.happy/terraform/envs/prod/main.tf
+++ b/api/.happy/terraform/envs/prod/main.tf
@@ -22,4 +22,8 @@ module "stack" {
   additional_env_vars_from_secrets = {
     items = ["hapi-prod-ssm-secrets"]
   }
+  additional_volumes_from_secrets = {
+    items    = ["hapi-prod-ssm-secrets"]
+    base_dir = "/go"
+  }
 }

--- a/api/.happy/terraform/envs/rdev/main.tf
+++ b/api/.happy/terraform/envs/rdev/main.tf
@@ -22,4 +22,8 @@ module "stack" {
   additional_env_vars_from_secrets = {
     items = ["hapi-rdev-ssm-secrets"]
   }
+  additional_volumes_from_secrets = {
+    items    = ["hapi-rdev-ssm-secrets"]
+    base_dir = "/go"
+  }
 }

--- a/api/.happy/terraform/envs/staging/main.tf
+++ b/api/.happy/terraform/envs/staging/main.tf
@@ -22,4 +22,8 @@ module "stack" {
   additional_env_vars_from_secrets = {
     items = ["hapi-staging-ssm-secrets"]
   }
+  additional_volumes_from_secrets = {
+    items    = ["hapi-staging-ssm-secrets"]
+    base_dir = "/go"
+  }
 }

--- a/api/Makefile
+++ b/api/Makefile
@@ -37,4 +37,4 @@ docker: ## Build docker image using scratch and Dockerfile.api in root project d
 	pushd ../ && docker build -t happy-api:dev -f Dockerfile.api .
 
 docker-dev:
-	aws-oidc exec --profile czi-si-readonly -- chamber exec happy-ldev-hapi -- docker-compose --profile happy-api up --build
+	aws-oidc exec --profile czi-si-readonly -- chamber exec happy-ldev-hapi -- docker-compose --profile hapi up --build

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,6 +1,7 @@
+version: "3.8"
 services:
   hapi:
-    image: 626314663667.dkr.ecr.us-west-2.amazonaws.com/hapi
+    image: hapi
     platform: linux/arm64
     build:
       context: ".."
@@ -14,11 +15,12 @@ services:
     profiles:
       - hapi
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - APP_ENV=docker-dev
       - HAPPY_DATABASE_HOST=db
-      - HAPPY_DATABASE_NAME=
+      - HAPPY_DATABASE_NAME=postgres
       - HAPPY_DATABASE_USER=postgres
       - HAPPY_DATABASE_PASSWORD=REPLACEME
       - HAPPY_DATABASE_PORT=5432
@@ -29,3 +31,12 @@ services:
     restart: always
     ports:
       - 5432:5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=REPLACEME
+      - POSTGRES_DB=postgres
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d postgres" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eo pipefail
 
-./happy-api
+reflex -g 'hapi-*-ssm-secrets/*' --shutdown-timeout=30000ms -s ./happy-api


### PR DESCRIPTION
Uses [reflex](https://github.com/cespare/reflex) to automatically restart the api when new happy env credentials are added.

How this works:
1. New credentials are added to SSM with this prefix `/hapi-staging-secrets-from-aws-param/` (added from here https://github.com/chanzuckerberg/happy/blob/c28be3a8e686ae84eb2ab0dbba90b02a9161fb08/terraform/modules/happy-tfe-okta-service-account/ssm_writer.tf#L6)
2. This module creates K8s secrets from the SSM params https://github.com/chanzuckerberg/hapi-infra/blob/45f940cf515c75cc6eb0232b0d89b3aca0cf14b7/terraform/envs/prod/secrets_from_aws_param/main.tf#L4
3. This PR maps the K8s secrets to a directory in the happy api pod(s)
4. `reflex` watches the directory and restarts the api when any of the files in the directory change