### PR TITLE
fix: Make integration test run on push to main, and not on pr

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,6 +1,7 @@
 on:
-    release:
-      types: [published]
+    push:
+      branches:
+        - main
     schedule:
       - cron: '0 11 * * *'
     workflow_dispatch:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,7 +1,6 @@
 on:
-    pull_request:
-      branches:
-        - 'main'
+    release:
+      types: [published]
     schedule:
       - cron: '0 11 * * *'
     workflow_dispatch:


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1667:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1667" title="CCIE-1667" target="_blank">CCIE-1667</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Running integration test on a PR blocks concurrent PRs (dependabot)</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Addresses [CCIE-1667].

[CCIE-1667]: https://czi-tech.atlassian.net/browse/CCIE-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ