### PR TITLE
fix: Prevent abrupt integration test cancellations

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,7 +10,7 @@ name: integration-test
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 jobs:
     integration-test:
       runs-on: [ARM64, self-hosted, Linux]


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1687:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1687" title="CCIE-1687" target="_blank">CCIE-1687</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy Integration test is being cancelled in-flight</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-1687]

[CCIE-1687]: https://czi-tech.atlassian.net/browse/CCIE-1687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ