### PR TITLE
fix: allow for a bucket policy to be specified

### DIFF
--- a/terraform/modules/happy-env-eks/s3.tf
+++ b/terraform/modules/happy-env-eks/s3.tf
@@ -1,11 +1,11 @@
 module "s3_buckets" {
   for_each          = var.s3_buckets
   source            = "github.com/chanzuckerberg/cztack//aws-s3-private-bucket?ref=v0.56.2"
-  project           = var.tags["project"]
-  env               = var.tags["env"]
-  service           = "happy"
-  owner             = var.tags["owner"]
+  project           = var.tags.project
+  env               = var.tags.env
+  service           = var.tags.service
+  owner             = var.tags.owner
   bucket_name       = each.value["name"]
-  bucket_policy     = ""
+  bucket_policy     = each.value["policy"]
   enable_versioning = true
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1702:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1702" title="CCIE-1702" target="_blank">CCIE-1702</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Allow for Bucket Policies to be Configured for Happy S3 Buckets</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-1702

This PR allows for bucket policies to be configured, which is required if roles outside the scope of the happy environment need to write to the bucket.