### PR TITLE
fix: Only Always restart policy is supported

### DIFF
--- a/terraform/modules/happy-service-eks/main.tf
+++ b/terraform/modules/happy-service-eks/main.tf
@@ -82,7 +82,7 @@ resource "kubernetes_deployment_v1" "deployment" {
         node_selector = {
           "kubernetes.io/arch" = var.platform_architecture
         }
-        restart_policy = var.fail_fast ? "Never" : "Always"
+        restart_policy = "Always"
 
         container {
           name              = var.container_name


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-865:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-865" title="CCIE-865" target="_blank">CCIE-865</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy update reports success on failed deployment when ECS rolls back the task version</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Done</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-865]

[CCIE-865]: https://czi-tech.atlassian.net/browse/CCIE-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ