### PR TITLE
fix: Skip coverage update on dependabot commits

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -69,6 +69,7 @@ jobs:
           cd cli && go mod tidy
 
       - name: Update coverage
+        if: github.actor!= 'dependabot[bot]'
         run: cd cli && make coverage-update
 
       - name: Commit updated coverage


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1714:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1714" title="CCIE-1714" target="_blank">CCIE-1714</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Skip coverage updates on dependabot PRs</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-1714]

[CCIE-1714]: https://czi-tech.atlassian.net/browse/CCIE-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ