### PR TITLE
feat: allow for multiple polices on IAM service account

### DIFF
--- a/terraform/modules/happy-iam-service-account-eks/README.md
+++ b/terraform/modules/happy-iam-service-account-eks/README.md
@@ -32,6 +32,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_iam_policies_json"></a> [aws\_iam\_policies\_json](#input\_aws\_iam\_policies\_json) | The additional AWS IAM policies to give to the pod. Backward compatibility with aws\_iam\_policy\_json | `list(string)` | `[]` | no |
 | <a name="input_aws_iam_policy_json"></a> [aws\_iam\_policy\_json](#input\_aws\_iam\_policy\_json) | The AWS IAM policy to give to the pod. | `string` | n/a | yes |
 | <a name="input_eks_cluster"></a> [eks\_cluster](#input\_eks\_cluster) | eks-cluster module output | <pre>object({<br>    cluster_id : string,<br>    cluster_arn : string,<br>    cluster_endpoint : string,<br>    cluster_ca : string,<br>    cluster_oidc_issuer_url : string,<br>    cluster_version : string,<br>    worker_iam_role_name : string,<br>    worker_security_group : string,<br>    oidc_provider_arn : string,<br>  })</pre> | n/a | yes |
 | <a name="input_iam_path"></a> [iam\_path](#input\_iam\_path) | IAM path for the role. | `string` | `""` | no |

--- a/terraform/modules/happy-iam-service-account-eks/main.tf
+++ b/terraform/modules/happy-iam-service-account-eks/main.tf
@@ -42,17 +42,23 @@ resource "kubernetes_service_account" "service_account" {
   automount_service_account_token = true
 }
 
+locals {
+  iam_policies = concat([var.aws_iam_policy_json], var.aws_iam_policies_json)
+}
+
 resource "aws_iam_policy" "policy" {
-  count       = var.aws_iam_policy_json == "" ? 0 : 1
+  count = local.iam_policies
+
   name        = aws_iam_role.role.name
   path        = "/"
-  description = "Stack policy for ${aws_iam_role.role.name}"
-  policy      = var.aws_iam_policy_json
+  description = "Service account policy ${count.index} for ${aws_iam_role.role.name}"
+  policy      = local.iam_policies[count.index]
   tags        = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "attach" {
-  count      = var.aws_iam_policy_json == "" ? 0 : 1
+  count = local.iam_policies
+
   role       = aws_iam_role.role.name
-  policy_arn = aws_iam_policy.policy[0].arn
+  policy_arn = aws_iam_policy.policy[count.index].arn
 }

--- a/terraform/modules/happy-iam-service-account-eks/variables.tf
+++ b/terraform/modules/happy-iam-service-account-eks/variables.tf
@@ -49,6 +49,11 @@ variable "max_session_duration" {
   default     = 3600
 }
 
+variable "aws_iam_policies_json" {
+  type        = list(string)
+  description = "The additional AWS IAM policies to give to the pod. Backward compatibility with aws_iam_policy_json"
+  default     = []
+}
 
 variable "aws_iam_policy_json" {
   type        = string


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1749:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1749" title="CCIE-1749" target="_blank">CCIE-1749</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Allow for Adding Multiple Policies to a Single Service Account Role</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-1749

This PR allows us to attach multiple policies to the same service account. I needed this because I ran out of bytes in a single policy.