### PR TITLE
fix: forgot length argument for count

### DIFF
--- a/terraform/modules/happy-iam-service-account-eks/main.tf
+++ b/terraform/modules/happy-iam-service-account-eks/main.tf
@@ -47,7 +47,7 @@ locals {
 }
 
 resource "aws_iam_policy" "policy" {
-  count = local.iam_policies
+  count = length(local.iam_policies)
 
   name        = aws_iam_role.role.name
   path        = "/"
@@ -57,7 +57,7 @@ resource "aws_iam_policy" "policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "attach" {
-  count = local.iam_policies
+  count = length(local.iam_policies)
 
   role       = aws_iam_role.role.name
   policy_arn = aws_iam_policy.policy[count.index].arn


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1749:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1749" title="CCIE-1749" target="_blank">CCIE-1749</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Allow for Adding Multiple Policies to a Single Service Account Role</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-1749](https://czi-tech.atlassian.net/browse/CCIE-1749)

oops

[CCIE-1749]: https://czi-tech.atlassian.net/browse/CCIE-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ