### PR TITLE
fix: make policy names unique

### DIFF
--- a/terraform/modules/happy-iam-service-account-eks/main.tf
+++ b/terraform/modules/happy-iam-service-account-eks/main.tf
@@ -49,7 +49,7 @@ locals {
 resource "aws_iam_policy" "policy" {
   count = length(local.iam_policies)
 
-  name        = aws_iam_role.role.name
+  name        = "${aws_iam_role.role.name}-${count.index}"
   path        = "/"
   description = "Service account policy ${count.index} for ${aws_iam_role.role.name}"
   policy      = local.iam_policies[count.index]


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1749:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1749" title="CCIE-1749" target="_blank">CCIE-1749</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Allow for Adding Multiple Policies to a Single Service Account Role</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-1749](https://czi-tech.atlassian.net/browse/CCIE-1749)

[CCIE-1749]: https://czi-tech.atlassian.net/browse/CCIE-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ