### PR TITLE
feat: Added app name field to be included in auto-generated field

### DIFF
--- a/shared/util/tf/tf_generator.go
+++ b/shared/util/tf/tf_generator.go
@@ -321,8 +321,7 @@ func (tf *TfGenerator) generateServiceValues(variable ModuleVariable, serviceCon
 				elem[k] = value
 			} else {
 				if _, ok := defaultValues[k]; !ok {
-
-					//return cty.NilVal, errors.Errorf("field '%s' is required, there's no value provided, and no default field value set in the module", k)
+					return cty.NilVal, errors.Errorf("field '%s' is required, there's no value provided, and no default field value set in the module", k)
 				} else if enforceConsistency {
 					// Needed to enforce type consistency, as cty.MapVal requires all values to be of the same type
 					elem[k] = defaultValues[k]

--- a/shared/util/tf/tf_generator.go
+++ b/shared/util/tf/tf_generator.go
@@ -104,6 +104,11 @@ var requiredVariables []variable = []variable{
 		Type:        "string",
 		Description: "Happy Path stack name",
 	},
+	{
+		Name:        "app",
+		Type:        "string",
+		Description: "Happy App Name",
+	},
 }
 
 const requiredTerraformVersion = ">= 1.3"
@@ -316,7 +321,8 @@ func (tf *TfGenerator) generateServiceValues(variable ModuleVariable, serviceCon
 				elem[k] = value
 			} else {
 				if _, ok := defaultValues[k]; !ok {
-					return cty.NilVal, errors.Errorf("field '%s' is required, there's no value provided, and no default field value set in the module", k)
+
+					//return cty.NilVal, errors.Errorf("field '%s' is required, there's no value provided, and no default field value set in the module", k)
 				} else if enforceConsistency {
 					// Needed to enforce type consistency, as cty.MapVal requires all values to be of the same type
 					elem[k] = defaultValues[k]


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1237:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1237" title="CCIE-1237" target="_blank">CCIE-1237</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>DRY -  happy stack app_name</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Tested locally using the debugger tools that runs `happy infra generate --force`. When this run is triggered, it would fail on this error, 
`[FATAL]: unable to generate HCL code: Unable to generate main.tf: unable to generate nested values: field 'name' is required, there's no value provided, and no default field value set in the module`. I commented out this [line](https://github.com/chanzuckerberg/happy/blob/main/shared/util/tf/tf_generator.go#L319) that was causing the issue to confirm the code work successfully.
<img width="1911" alt="Screenshot 2023-08-25 at 11 26 28 AM" src="https://github.com/chanzuckerberg/happy/assets/104519112/76af58f4-b3cb-420d-bf5a-b23115f88bff">

I think the error above is caused by this [line](https://github.com/chanzuckerberg/happy/blob/main/terraform/modules/happy-stack-eks/variables.tf#L47). The TF generator required an default value but its not set in the stack module, but it doesn't make sense to set a default value for service name.