### PR TITLE
fix: Make workspace run message consistent

### DIFF
--- a/shared/workspace_repo/workspace.go
+++ b/shared/workspace_repo/workspace.go
@@ -268,7 +268,7 @@ func (s *TFEWorkspace) RunConfigVersion(ctx context.Context, configVersionId str
 	options := &tfe.RunCreateOptions{
 		Type:      "runs",
 		IsDestroy: tfe.Bool(false),
-		Message:   tfe.String("Queued from happy cli"),
+		Message:   tfe.String(fmt.Sprintf("Happy %s queued from cli", util.GetVersion().Version)),
 		ConfigurationVersion: &tfe.ConfigurationVersion{
 			ID:          configVersionId,
 			Speculative: false,


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1754:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1754" title="CCIE-1754" target="_blank">CCIE-1754</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy TFE/TFC messages are inconsistent</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-1754]. Addresses message consistency issues.

[CCIE-1754]: https://czi-tech.atlassian.net/browse/CCIE-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ