### PR TITLE
fix: Notify user to restart docker engine, allow pre-release for docker compose

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -230,7 +230,7 @@ func validateStackNameAvailable(ctx context.Context, stackService *stackservice.
 				if meta.AppName == happyClient.HappyConfig.App() {
 					return nil
 				}
-				return errors.Errorf("this stack exists, but in a different app ('%s')", meta.AppName)
+				return errors.Errorf("this stack exists, but in a different app ('%s'), you cannot manipulate it from this app", meta.AppName)
 			}
 		}
 

--- a/examples/nodejs_downstream/backend/Dockerfile
+++ b/examples/nodejs_downstream/backend/Dockerfile
@@ -1,6 +1,6 @@
 # 1. update this base image tag to update the base image
 # 2. update this path based on the name of your stack (ie. /stackname/envname/servicename)
-FROM 401986845158.dkr.ecr.us-west-2.amazonaws.com/test1/rdev/base:v1.0.1
+FROM ACCOUNTID.dkr.ecr.us-west-2.amazonaws.com/test1/rdev/base:v1.0.1
 COPY ./ ./
 RUN npm install
 CMD [ "node", "app.js" ]

--- a/shared/util/preconditions.go
+++ b/shared/util/preconditions.go
@@ -30,7 +30,6 @@ func ValidateEnvironment(ctx context.Context, validations ...ValidationCallback)
 	var errs *multierror.Error
 
 	for _, validation := range validations {
-		log.Infof("running validation %v", validation)
 		err := validation(ctx)
 		if err != nil {
 			errs = multierror.Append(errs, err)

--- a/shared/util/preconditions.go
+++ b/shared/util/preconditions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type ValidationCallback = func(context.Context) error
@@ -29,6 +30,7 @@ func ValidateEnvironment(ctx context.Context, validations ...ValidationCallback)
 	var errs *multierror.Error
 
 	for _, validation := range validations {
+		log.Infof("running validation %v", validation)
 		err := validation(ctx)
 		if err != nil {
 			errs = multierror.Append(errs, err)
@@ -63,7 +65,7 @@ func ValidateDockerInstalled(ctx context.Context) error {
 func ValidateMinDockerComposeVersion(ctx context.Context) error {
 	var errs *multierror.Error
 
-	dockerComposeMinVersion, err := semver.NewConstraint(">= v2")
+	dockerComposeMinVersion, err := semver.NewConstraint(">= v2.0.0-0")
 	if err != nil {
 		return errors.Wrap(err, "could not establish docker compose version")
 	}
@@ -130,6 +132,7 @@ func ValidateDockerEngineRunning(ctx context.Context) error {
 		errs = multierror.Append(errs, errors.Wrap(err, "docker engine is not running, follow https://docs.docker.com/get-docker/"))
 	}
 
+	log.Debug("checking docker engine is running; if the process freezes up, please restart docker engine")
 	_, err = client.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
 		errs = multierror.Append(errs, errors.Wrap(err, "cannot connect to docker engine"))


### PR DESCRIPTION
Version constraint altered to fix the following error: 
```
[FATAL]: 2 errors occurred:
        * docker compose >= V2 required but 2.20.2-desktop.1 was detected, please follow https://docs.docker.com/compose/cli-command/
        * 2.20.2-desktop.1 is a prerelease version and the constraint is only looking for release versions
```
<!--JIRA_VALIDATE_START:CCIE-1757:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1757" title="CCIE-1757" target="_blank">CCIE-1757</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy create freezes</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-1757]

[CCIE-1757]: https://czi-tech.atlassian.net/browse/CCIE-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ