### PR TITLE
fix: using the wrong AWS profile when promoting images

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -90,7 +90,7 @@ func runCreate(
 		validateTFEBackLog(ctx, happyClient.AWSBackend),
 		validateStackExistsCreate(ctx, stackName, happyClient, message),
 		validateECRExists(ctx, stackName, terraformECRTargetPathTemplate, happyClient, message),
-		validateImageExists(ctx, createTag, skipCheckTag, imageSrcEnv, imageSrcStack, happyClient),
+		validateImageExists(ctx, createTag, skipCheckTag, imageSrcEnv, imageSrcStack, happyClient, cmd.Flags().Changed(config.FlagAWSProfile)),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed one of the happy client validations")

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -138,7 +138,13 @@ func configureArtifactBuilder(
 
 type validation func() error
 
-func validateImageExists(ctx context.Context, createTag, skipCheckTag bool, imageSrcEnv, imageSrcStack string, happyClient *HappyClient) validation {
+func validateImageExists(
+	ctx context.Context,
+	createTag, skipCheckTag bool,
+	imageSrcEnv, imageSrcStack string,
+	happyClient *HappyClient,
+	useAWSProfile bool,
+) validation {
 	return func() error {
 		logrus.Debug("Running validateImageExists()")
 		if skipCheckTag {
@@ -158,7 +164,7 @@ func validateImageExists(ctx context.Context, createTag, skipCheckTag bool, imag
 			}
 
 			// make a client associated with the env we are pulling from
-			bs, err := config.NewBootstrapConfigForEnv(imageSrcEnv)
+			bs, err := config.NewBootstrapConfigForEnv(imageSrcEnv, useAWSProfile)
 			if err != nil {
 				return errors.Wrapf(err, "unable to bootstrap %s env", imageSrcEnv)
 			}

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -79,7 +79,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		validateTFEBackLog(ctx, happyClient.AWSBackend),
 		validateStackExistsUpdate(ctx, stackName, happyClient),
 		validateECRExists(ctx, stackName, terraformECRTargetPathTemplate, happyClient),
-		validateImageExists(ctx, createTag, skipCheckTag, imageSrcEnv, imageSrcStack, happyClient),
+		validateImageExists(ctx, createTag, skipCheckTag, imageSrcEnv, imageSrcStack, happyClient, cmd.Flags().Changed(config.FlagAWSProfile)),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed one of the happy client validations")

--- a/shared/config/bootstrap.go
+++ b/shared/config/bootstrap.go
@@ -18,7 +18,7 @@ const (
 	flagHappyProjectRoot = "project-root"
 	flagHappyConfigPath  = "config-path"
 	flagEnv              = "env"
-	flagAWSProfile       = "aws-profile"
+	FlagAWSProfile       = "aws-profile"
 
 	flagComposeEnvFile          = "docker-compose-env-file"
 	flagDockerComposeConfigPath = "docker-compose-config-path"
@@ -55,7 +55,7 @@ func ConfigureCmdWithBootstrapConfig(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&dockerComposeConfigPath, flagDockerComposeConfigPath, "", "Specify the path to your Happy project's docker compose file")
 	cmd.PersistentFlags().StringVar(&env, flagEnv, "", "Specify a Happy env")
 	cmd.PersistentFlags().StringVar(&composeEnvFile, flagComposeEnvFile, "", "Environment file to pass to docker compose")
-	cmd.PersistentFlags().StringVar(&awsProfile, flagAWSProfile, "", "Override the AWS profile to use. If speficied but empty, will use the default credentil chain.")
+	cmd.PersistentFlags().StringVar(&awsProfile, FlagAWSProfile, "", "Override the AWS profile to use. If speficied but empty, will use the default credentil chain.")
 }
 
 type Bootstrap struct {
@@ -127,11 +127,11 @@ func searchHappyRoot(path string) (string, error) {
 }
 
 func NewBootstrapConfig(cmd *cobra.Command) (*Bootstrap, error) {
-	return newBootstrap(env, cmd.Flags().Changed(flagAWSProfile))
+	return newBootstrap(env, cmd.Flags().Changed(FlagAWSProfile))
 }
 
-func NewBootstrapConfigForEnv(env string) (*Bootstrap, error) {
-	return newBootstrap(env, false)
+func NewBootstrapConfigForEnv(env string, useAWSProfile bool) (*Bootstrap, error) {
+	return newBootstrap(env, useAWSProfile)
 }
 
 // This is a simple bootstrap used for the bootstrapping command

--- a/shared/config/bootstrap_test.go
+++ b/shared/config/bootstrap_test.go
@@ -50,7 +50,7 @@ func setFlags(basedir string, setflags map[string]string) {
 	if val, ok := setflags[flagDockerComposeConfigPath]; ok {
 		dockerComposeConfigPath = set(val)
 	}
-	if val, ok := setflags[flagAWSProfile]; ok {
+	if val, ok := setflags[FlagAWSProfile]; ok {
 		awsProfile = val
 	}
 	if val, ok := setflags[flagEnv]; ok {


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1776:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1776" title="CCIE-1776" target="_blank">CCIE-1776</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy CLI Promote Images Does Not Obey --aws-profile Flag</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-1776

## Summary

This fixes a bug in the happy CLI that was trying to use the happy config.json every time image promotion happened. In Github Actions, we still want to obey the `--aws-profile ""` flag. This PR fixes this issue to look at this flag when making its happy clients for the various environments it is trying to promote from.