### PR TITLE
fix: better error reporting for happy cli and happy tf provider

### DIFF
--- a/api/pkg/request/auth.go
+++ b/api/pkg/request/auth.go
@@ -136,7 +136,7 @@ type MultiOIDCProvider struct {
 }
 
 func (m *MultiOIDCProvider) Verify(ctx context.Context, idToken string) (*oidc.IDToken, error) {
-	var errs error
+	errs := &multierror.Error{}
 	for _, verifier := range m.verifiers {
 		idToken, err := verifier.Verify(ctx, idToken)
 		if err != nil {
@@ -145,7 +145,7 @@ func (m *MultiOIDCProvider) Verify(ctx context.Context, idToken string) (*oidc.I
 		}
 		return idToken, nil
 	}
-	return nil, errors.Wrap(errs, "unable to verify the ID token with any of the configured OIDC providers")
+	return nil, errors.Wrap(errs.ErrorOrNil(), "unable to verify the ID token with any of the configured OIDC providers")
 }
 
 func MakeMultiOIDCVerifier(verifiers ...OIDCVerifier) OIDCVerifier {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -199,7 +199,8 @@ func CheckLockedHappyVersion(cmd *cobra.Command) error {
 		return nil
 	}
 
-	if !versionMatch {
+	// version will be undefined for local builds of the CLI and we don't want it to break here when testing locally
+	if !versionMatch && cliVersion != "undefined" {
 		return errors.Errorf("installed Happy version (%s) does not match locked version in .happy/version.lock (%s)", cliVersion, lockedVersion)
 	}
 

--- a/shared/client/util.go
+++ b/shared/client/util.go
@@ -45,11 +45,11 @@ func InspectForErrors(resp *http.Response) error {
 		}
 		return errs
 	default:
-		var errorMessage map[string]interface{}
+		var errorMessage interface{}
 		err := ParseResponse(resp, &errorMessage)
 		if err != nil {
 			return errors.Wrapf(err, "unable to parse resp body as JSON for status code %+v", resp.StatusCode)
 		}
-		return errors.New(fmt.Sprintf("%+v", errorMessage))
+		return errors.New(fmt.Sprintf("status code %+v: %+v", resp.StatusCode, errorMessage))
 	}
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1124:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1124" title="CCIE-1124" target="_blank">CCIE-1124</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Better Error/Log Writing For the Happy API</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

- Improved error reporting for `MultiOIDCProvider` (by using multierrors)
- Improved error parsing for Hapi responses in the CLI and TF provider

Examples of fixed parsing:
<img width="630" alt="Screenshot 2023-09-14 at 10 52 44 AM" src="https://github.com/chanzuckerberg/happy/assets/105455169/1bebbca8-1968-4cf6-b0cc-7731570be2f8">

This one shows fixed parsing as well as the use of multierror:
<img width="1163" alt="Screenshot 2023-09-14 at 10 54 01 AM" src="https://github.com/chanzuckerberg/happy/assets/105455169/ee4bfcbe-9ca3-4de0-b62f-dad98a91e742">
