### PR TITLE
fix: Add permissions to github ci role to allow retrieval of ecr image scanning

### DIFF
--- a/terraform/modules/happy-env-eks/README.md
+++ b/terraform/modules/happy-env-eks/README.md
@@ -1,5 +1,4 @@
 https://docs.google.com/drawings/d/1AsJts2qCmw7685A6WZPDb5ApkXyuPRc27Lg3zzWuPaA/edit
-
 <!-- bump3  -->
 <!-- START -->
 ## Requirements

--- a/terraform/modules/happy-github-ci-role/ecr.tf
+++ b/terraform/modules/happy-github-ci-role/ecr.tf
@@ -39,7 +39,12 @@ data "aws_iam_policy_document" "ecr-scanner" {
 
     actions = [
       "ecr:BatchGetRepositoryScanningConfiguration",
-      "ecr:GetRegistryScanningConfiguration"
+      "ecr:GetRegistryScanningConfiguration",
+      "ecr:DescribeImageScanFindings",
+      "ecr:StartImageScan",
+      "ecr:PutImageScanningConfiguration",
+      "ecr:PutRegistryScanningConfiguration",
+      "ecr:PutImageTagMutability"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1906:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1906" title="CCIE-1906" target="_blank">CCIE-1906</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>ECR scan times out</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-1906]

[CCIE-1906]: https://czi-tech.atlassian.net/browse/CCIE-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ