### PR TITLE
feat: add custom claim to jwts sent from happy provider to happy api

### DIFF
--- a/terraform/provider/pkg/provider/provider_test.go
+++ b/terraform/provider/pkg/provider/provider_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	"github.com/chanzuckerberg/happy/shared/client"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type APIMock struct {
@@ -43,4 +45,36 @@ func testPreCheck(t *testing.T) {
 	if err := os.Getenv("HAPPY_API_BASE_URL"); err == "" {
 		t.Fatal("HAPPY_API_BASE_URL must be set for acceptance tests")
 	}
+}
+
+func TestGetClaimsValid(t *testing.T) {
+	claimsValues := ClaimsValues{
+		issuer:        "issuer-value",
+		audience:      "audience-value",
+		scope:         "scope-value",
+		assumeRoleARN: "arn:aws:iam::1234567890:role/fake-role",
+	}
+	claims := getClaims(claimsValues)
+
+	r := require.New(t)
+	r.Equal(claims.Audience, jwt.ClaimStrings(jwt.ClaimStrings{claimsValues.audience}))
+	r.Equal(claims.Issuer, claimsValues.issuer)
+	r.Equal(claims.Actor, claimsValues.assumeRoleARN)
+	r.Equal(claims.Valid(), nil)
+}
+
+func TestGetClaimsInalid(t *testing.T) {
+	claimsValues := ClaimsValues{
+		issuer:        "issuer-value",
+		audience:      "audience-value",
+		scope:         "scope-value",
+		assumeRoleARN: "",
+	}
+	claims := getClaims(claimsValues)
+
+	r := require.New(t)
+	r.Equal(claims.Audience, jwt.ClaimStrings(jwt.ClaimStrings{claimsValues.audience}))
+	r.Equal(claims.Issuer, claimsValues.issuer)
+	r.Equal(claims.Actor, claimsValues.assumeRoleARN)
+	r.NotEqual(claims.Valid(), nil)
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1780:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1780" title="CCIE-1780" target="_blank">CCIE-1780</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Create custom claim for happy api tokens from happy tf provider</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Adds a custom Actor claim to jwts generated by the happy provider. This allows us to better label transactions sent to Sentry from the happy api.