### PR TITLE
fix: pass role to assume arn to token providers

### DIFF
--- a/terraform/provider/pkg/provider/provider.go
+++ b/terraform/provider/pkg/provider/provider.go
@@ -44,9 +44,10 @@ func MakeKMSKeyTFProvider(ctx context.Context, provConfig *Config, appCreds *sts
 		}),
 		keyID: *provConfig.KMSKeyID,
 		ClaimsValues: ClaimsValues{
-			issuer:   provConfig.OIDCIssuer,
-			audience: fmt.Sprintf("https://czi-prod.okta.com/oauth2/%s/v1/token", provConfig.OIDCAuthzID),
-			scope:    provConfig.OIDCScope,
+			issuer:        provConfig.OIDCIssuer,
+			audience:      fmt.Sprintf("https://czi-prod.okta.com/oauth2/%s/v1/token", provConfig.OIDCAuthzID),
+			scope:         provConfig.OIDCScope,
+			assumeRoleARN: provConfig.AssumeRoleARN,
 		},
 	}, nil
 }
@@ -118,9 +119,10 @@ func MakePrivateKeyTFTokenProvider(provConfig *Config) (client.TokenProvider, er
 	return &PrivateKeyTFTokenProvider{
 		signingKey: signingKey,
 		ClaimsValues: ClaimsValues{
-			issuer:   provConfig.OIDCIssuer,
-			audience: fmt.Sprintf("https://czi-prod.okta.com/oauth2/%s/v1/token", provConfig.OIDCAuthzID),
-			scope:    provConfig.OIDCScope,
+			issuer:        provConfig.OIDCIssuer,
+			audience:      fmt.Sprintf("https://czi-prod.okta.com/oauth2/%s/v1/token", provConfig.OIDCAuthzID),
+			scope:         provConfig.OIDCScope,
+			assumeRoleARN: provConfig.AssumeRoleARN,
 		},
 	}, nil
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1780:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1780" title="CCIE-1780" target="_blank">CCIE-1780</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Create custom claim for happy api tokens from happy tf provider</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Follow-up to https://github.com/chanzuckerberg/happy/pull/2505