### PR TITLE
feat: autogenerate default_tag field in aws provider when using happy infra generate command

### DIFF
--- a/shared/util/tf/tf_generator.go
+++ b/shared/util/tf/tf_generator.go
@@ -392,6 +392,22 @@ func (tf TfGenerator) generateAwsProvider(rootBody *hclwrite.Body, alias, accoun
 
 	assumeRoleBlockBody := awsProviderBody.AppendNewBlock("assume_role", nil).Body()
 	assumeRoleBlockBody.SetAttributeRaw("role_arn", tokens(fmt.Sprintf("\"arn:aws:iam::%s:role/%s\"", accountIdExpr, roleExpr)))
+
+	defaultTagsBlockBody := awsProviderBody.AppendNewBlock("default_tags", nil).Body()
+	tagsBlockBody := defaultTagsBlockBody.AppendNewBlock("tags", nil).Body()
+	tagsBlockBody.SetAttributeRaw("TFC_RUN_ID", tokens("var.TFC_RUN_ID"))
+	tagsBlockBody.SetAttributeRaw("TFC_WORKSPACE_NAME", tokens("var.TFC_WORKSPACE_NAME"))
+	tagsBlockBody.SetAttributeRaw("TFC_WORKSPACE_SLUG", tokens("var.TFC_WORKSPACE_SLUG"))
+	tagsBlockBody.SetAttributeRaw("TFC_CONFIGURATION_VERSION_GIT_BRANCH", tokens("var.TFC_CONFIGURATION_VERSION_GIT_BRANCH"))
+	tagsBlockBody.SetAttributeRaw("TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA", tokens("var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA"))
+	tagsBlockBody.SetAttributeRaw("TFC_CONFIGURATION_VERSION_GIT_TAG", tokens("var.TFC_CONFIGURATION_VERSION_GIT_TAG"))
+	tagsBlockBody.SetAttributeRaw("TFC_PROJECT_NAME", tokens("var.TFC_PROJECT_NAME"))
+	tagsBlockBody.SetAttributeRaw("project", tokens("var.tags.project"))
+	tagsBlockBody.SetAttributeRaw("env", tokens("var.tags.env"))
+	tagsBlockBody.SetAttributeRaw("service", tokens("var.tags.service"))
+	tagsBlockBody.SetAttributeRaw("owner", tokens("var.tags.owner"))
+	tagsBlockBody.SetAttributeRaw("managedBy", tokens("terraform"))
+
 	awsProviderBody.SetAttributeRaw("allowed_account_ids", tokens(fmt.Sprintf("[\"%s\"]", accountIdExpr)))
 	return nil
 }

--- a/shared/util/tf/tf_generator.go
+++ b/shared/util/tf/tf_generator.go
@@ -395,17 +395,19 @@ func (tf TfGenerator) generateAwsProvider(rootBody *hclwrite.Body, alias, accoun
 
 	defaultTagsBlockBody := awsProviderBody.AppendNewBlock("default_tags", nil).Body()
 	tagsBlockBody := defaultTagsBlockBody.AppendNewBlock("tags", nil).Body()
-	tagsBlockBody.SetAttributeRaw("TFC_RUN_ID", tokens("var.TFC_RUN_ID"))
-	tagsBlockBody.SetAttributeRaw("TFC_WORKSPACE_NAME", tokens("var.TFC_WORKSPACE_NAME"))
-	tagsBlockBody.SetAttributeRaw("TFC_WORKSPACE_SLUG", tokens("var.TFC_WORKSPACE_SLUG"))
-	tagsBlockBody.SetAttributeRaw("TFC_CONFIGURATION_VERSION_GIT_BRANCH", tokens("var.TFC_CONFIGURATION_VERSION_GIT_BRANCH"))
-	tagsBlockBody.SetAttributeRaw("TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA", tokens("var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA"))
-	tagsBlockBody.SetAttributeRaw("TFC_CONFIGURATION_VERSION_GIT_TAG", tokens("var.TFC_CONFIGURATION_VERSION_GIT_TAG"))
-	tagsBlockBody.SetAttributeRaw("TFC_PROJECT_NAME", tokens("var.TFC_PROJECT_NAME"))
-	tagsBlockBody.SetAttributeRaw("project", tokens("var.tags.project"))
-	tagsBlockBody.SetAttributeRaw("env", tokens("var.tags.env"))
-	tagsBlockBody.SetAttributeRaw("service", tokens("var.tags.service"))
-	tagsBlockBody.SetAttributeRaw("owner", tokens("var.tags.owner"))
+
+	tagsAttrs := [...]string{"TFC_RUN_ID", "TFC_WORKSPACE_NAME", "TFC_WORKSPACE_SLUG", "TFC_CONFIGURATION_VERSION_GIT_BRANCH",
+		"TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA", "TFC_CONFIGURATION_VERSION_GIT_TAG", "TFC_PROJECT_NAME",
+		"project", "env", "service", "owner"}
+	for _, tagAttr := range tagsAttrs {
+		s := ""
+		if strings.HasPrefix(tagAttr, "TFC_") {
+			s = fmt.Sprintf("coalesce(var.%s, \"unknown\")", tagAttr)
+		} else {
+			s = fmt.Sprintf("coalesce(var.tags.%s, \"unknown\")", tagAttr)
+		}
+		tagsBlockBody.SetAttributeRaw(tagAttr, tokens(s))
+	}
 	tagsBlockBody.SetAttributeRaw("managedBy", tokens("terraform"))
 
 	awsProviderBody.SetAttributeRaw("allowed_account_ids", tokens(fmt.Sprintf("[\"%s\"]", accountIdExpr)))


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1926:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1926" title="CCIE-1926" target="_blank">CCIE-1926</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Create Default Tag in AWS Provider in fogg.tf</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Similar to `fogg.tf`, we want to tag the AWS resources with the following format
```
provider "aws" {

  region = "us-west-2"


  assume_role {
    role_arn = "arn:aws:iam::626314663667:role/tfe-si"
  }

  # this is the new way of injecting AWS tags to all AWS resources
  # var.tags should be considered deprecated
  default_tags {
    tags = {
      TFC_RUN_ID                               = var.TFC_RUN_ID
      TFC_WORKSPACE_NAME                       = var.TFC_WORKSPACE_NAME
      TFC_WORKSPACE_SLUG                       = var.TFC_WORKSPACE_SLUG
      TFC_CONFIGURATION_VERSION_GIT_BRANCH     = var.TFC_CONFIGURATION_VERSION_GIT_BRANCH
      TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA = var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA
      TFC_CONFIGURATION_VERSION_GIT_TAG        = var.TFC_CONFIGURATION_VERSION_GIT_TAG
      TFC_PROJECT_NAME                         = var.TFC_PROJECT_NAME
      project                                  = var.tags.project
      env                                      = var.tags.env
      service                                  = var.tags.service
      owner                                    = var.tags.owner
      managedBy                                = "terraform"
    }
  }
  allowed_account_ids = ["626314663667"]
}
```
Confirmed this change by using debugger with this launch.json config
```
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Launch Package",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "../happy/cli",
            "args": ["infra", "generate"],
            "cwd": "../happy/examples/typical_app"
        }
    ]
}
```

<img width="1711" alt="Screenshot 2023-10-03 at 3 59 18 PM" src="https://github.com/chanzuckerberg/happy/assets/104519112/4c94a91b-f206-46df-a31e-e9e813de94c8">

https://github.com/chanzuckerberg/fogg/blob/main/templates/templates/common/aws_provider.tmpl