### PR TITLE
fix: duplicate target group names

### DIFF
--- a/terraform/modules/happy-service-eks/target_group_only.tf
+++ b/terraform/modules/happy-service-eks/target_group_only.tf
@@ -4,6 +4,10 @@ resource "random_pet" "this" {
   }
 }
 
+locals {
+  target_group_name = "${random_pet.this.keepers.target_group_name}_${random_pet.this.id}"
+}
+
 data "aws_lb" "this" {
   count = var.routing.service_type == "TARGET_GROUP_ONLY" ? 1 : 0
 
@@ -20,7 +24,7 @@ data "aws_lb_listener" "this" {
 resource "aws_lb_target_group" "this" {
   count = var.routing.service_type == "TARGET_GROUP_ONLY" ? 1 : 0
 
-  name     = random_pet.this.keepers.target_group_name
+  name     = local.target_group_name
   port     = var.routing.service_port
   protocol = "HTTP"
   vpc_id   = var.cloud_env.vpc_id
@@ -55,7 +59,7 @@ resource "kubernetes_manifest" "this" {
     kind       = "TargetGroupBinding"
 
     metadata = {
-      name      = random_pet.this.keepers.target_group_name
+      name      = local.target_group_name
       namespace = var.k8s_namespace
 
     }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1985:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1985" title="CCIE-1985" target="_blank">CCIE-1985</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy: TARGET_GROUP_ONLY stacks cannot be deleted and recreated</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-1985?atlOrigin=eyJpIjoiZDI3Y2ExZWZjYzI0NDQxZTk0ODA4ZjUzNDRiNGMzNzciLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## Summary

We need to use the random pet ID to get an actual random ID attached to the target group name. Otherwise, stacks of the same name will conflict.