### PR TITLE
fix: trim the target group name to only 32 chars

### DIFF
--- a/terraform/modules/happy-service-eks/target_group_only.tf
+++ b/terraform/modules/happy-service-eks/target_group_only.tf
@@ -6,7 +6,7 @@ resource "random_pet" "this" {
 
 locals {
   # only hyphens and a max of 32 characters
-  target_group_name = substr("${random_pet.this.keepers.target_group_name}-${random_pet.this.id}", 0, 32)
+  target_group_name = replace(substr("${random_pet.this.keepers.target_group_name}-${random_pet.this.id}", 0, 32), "_", "-")
 }
 
 data "aws_lb" "this" {

--- a/terraform/modules/happy-service-eks/target_group_only.tf
+++ b/terraform/modules/happy-service-eks/target_group_only.tf
@@ -5,7 +5,8 @@ resource "random_pet" "this" {
 }
 
 locals {
-  target_group_name = "${random_pet.this.keepers.target_group_name}_${random_pet.this.id}"
+  # only hyphens and a max of 32 characters
+  target_group_name = substr("${random_pet.this.keepers.target_group_name}-${random_pet.this.id}", 0, 32)
 }
 
 data "aws_lb" "this" {

--- a/terraform/modules/happy-service-eks/target_group_only.tf
+++ b/terraform/modules/happy-service-eks/target_group_only.tf
@@ -6,7 +6,7 @@ resource "random_pet" "this" {
 
 locals {
   # only hyphens and a max of 32 characters
-  target_group_name = replace(substr("${random_pet.this.keepers.target_group_name}-${random_pet.this.id}", 0, 32), "_", "-")
+  target_group_name = replace(substr("${random_pet.this.id}", 0, 32), "_", "-")
 }
 
 data "aws_lb" "this" {


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1985:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1985" title="CCIE-1985" target="_blank">CCIE-1985</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy: TARGET_GROUP_ONLY stacks cannot be deleted and recreated</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-1985](https://czi-tech.atlassian.net/browse/CCIE-1985?atlOrigin=eyJpIjoiZDI3Y2ExZWZjYzI0NDQxZTk0ODA4ZjUzNDRiNGMzNzciLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Summary 

AWS has annoying and different name requirements. This fixes the name requirements for target group names. 

## Notes

* Target groups can be a most 32 chars
* Target groups can't have underscores

[CCIE-1985]: https://czi-tech.atlassian.net/browse/CCIE-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ