### PR TITLE
feat: add 'source' column to app_configs table

### DIFF
--- a/api/pkg/ent/appconfig.go
+++ b/api/pkg/ent/appconfig.go
@@ -32,7 +32,9 @@ type AppConfig struct {
 	// Key holds the value of the "key" field.
 	Key string `json:"key,omitempty"`
 	// Value holds the value of the "value" field.
-	Value        string `json:"value,omitempty"`
+	Value string `json:"value,omitempty"`
+	// 'stack' if the config is for a specific stack or 'environment' if available to all stacks in the environment
+	Source       appconfig.Source `json:"source,omitempty"`
 	selectValues sql.SelectValues
 }
 
@@ -43,7 +45,7 @@ func (*AppConfig) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case appconfig.FieldID:
 			values[i] = new(sql.NullInt64)
-		case appconfig.FieldAppName, appconfig.FieldEnvironment, appconfig.FieldStack, appconfig.FieldKey, appconfig.FieldValue:
+		case appconfig.FieldAppName, appconfig.FieldEnvironment, appconfig.FieldStack, appconfig.FieldKey, appconfig.FieldValue, appconfig.FieldSource:
 			values[i] = new(sql.NullString)
 		case appconfig.FieldCreatedAt, appconfig.FieldUpdatedAt, appconfig.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -117,6 +119,12 @@ func (ac *AppConfig) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				ac.Value = value.String
 			}
+		case appconfig.FieldSource:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field source", values[i])
+			} else if value.Valid {
+				ac.Source = appconfig.Source(value.String)
+			}
 		default:
 			ac.selectValues.Set(columns[i], values[i])
 		}
@@ -178,6 +186,9 @@ func (ac *AppConfig) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("value=")
 	builder.WriteString(ac.Value)
+	builder.WriteString(", ")
+	builder.WriteString("source=")
+	builder.WriteString(fmt.Sprintf("%v", ac.Source))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/api/pkg/ent/appconfig/appconfig.go
+++ b/api/pkg/ent/appconfig/appconfig.go
@@ -3,8 +3,10 @@
 package appconfig
 
 import (
+	"fmt"
 	"time"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 )
 
@@ -29,6 +31,8 @@ const (
 	FieldKey = "key"
 	// FieldValue holds the string denoting the value field in the database.
 	FieldValue = "value"
+	// FieldSource holds the string denoting the source field in the database.
+	FieldSource = "source"
 	// Table holds the table name of the appconfig in the database.
 	Table = "app_configs"
 )
@@ -44,6 +48,7 @@ var Columns = []string{
 	FieldStack,
 	FieldKey,
 	FieldValue,
+	FieldSource,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -56,7 +61,13 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+// Note that the variables below are initialized by the runtime
+// package on the initialization of the application. Therefore,
+// it should be imported in the main as follows:
+//
+//	import _ "github.com/chanzuckerberg/happy/api/pkg/ent/runtime"
 var (
+	Hooks [1]ent.Hook
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -66,6 +77,32 @@ var (
 	// DefaultStack holds the default value on creation for the "stack" field.
 	DefaultStack string
 )
+
+// Source defines the type for the "source" enum field.
+type Source string
+
+// SourceEnvironment is the default value of the Source enum.
+const DefaultSource = SourceEnvironment
+
+// Source values.
+const (
+	SourceStack       Source = "stack"
+	SourceEnvironment Source = "environment"
+)
+
+func (s Source) String() string {
+	return string(s)
+}
+
+// SourceValidator is a validator for the "source" field enum values. It is called by the builders before save.
+func SourceValidator(s Source) error {
+	switch s {
+	case SourceStack, SourceEnvironment:
+		return nil
+	default:
+		return fmt.Errorf("appconfig: invalid enum value for source field: %q", s)
+	}
+}
 
 // OrderOption defines the ordering options for the AppConfig queries.
 type OrderOption func(*sql.Selector)
@@ -113,4 +150,9 @@ func ByKey(opts ...sql.OrderTermOption) OrderOption {
 // ByValue orders the results by the value field.
 func ByValue(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldValue, opts...).ToFunc()
+}
+
+// BySource orders the results by the source field.
+func BySource(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSource, opts...).ToFunc()
 }

--- a/api/pkg/ent/appconfig/where.go
+++ b/api/pkg/ent/appconfig/where.go
@@ -549,6 +549,26 @@ func ValueContainsFold(v string) predicate.AppConfig {
 	return predicate.AppConfig(sql.FieldContainsFold(FieldValue, v))
 }
 
+// SourceEQ applies the EQ predicate on the "source" field.
+func SourceEQ(v Source) predicate.AppConfig {
+	return predicate.AppConfig(sql.FieldEQ(FieldSource, v))
+}
+
+// SourceNEQ applies the NEQ predicate on the "source" field.
+func SourceNEQ(v Source) predicate.AppConfig {
+	return predicate.AppConfig(sql.FieldNEQ(FieldSource, v))
+}
+
+// SourceIn applies the In predicate on the "source" field.
+func SourceIn(vs ...Source) predicate.AppConfig {
+	return predicate.AppConfig(sql.FieldIn(FieldSource, vs...))
+}
+
+// SourceNotIn applies the NotIn predicate on the "source" field.
+func SourceNotIn(vs ...Source) predicate.AppConfig {
+	return predicate.AppConfig(sql.FieldNotIn(FieldSource, vs...))
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.AppConfig) predicate.AppConfig {
 	return predicate.AppConfig(sql.AndPredicates(predicates...))

--- a/api/pkg/ent/appconfig_create.go
+++ b/api/pkg/ent/appconfig_create.go
@@ -102,6 +102,20 @@ func (acc *AppConfigCreate) SetValue(s string) *AppConfigCreate {
 	return acc
 }
 
+// SetSource sets the "source" field.
+func (acc *AppConfigCreate) SetSource(a appconfig.Source) *AppConfigCreate {
+	acc.mutation.SetSource(a)
+	return acc
+}
+
+// SetNillableSource sets the "source" field if the given value is not nil.
+func (acc *AppConfigCreate) SetNillableSource(a *appconfig.Source) *AppConfigCreate {
+	if a != nil {
+		acc.SetSource(*a)
+	}
+	return acc
+}
+
 // SetID sets the "id" field.
 func (acc *AppConfigCreate) SetID(u uint) *AppConfigCreate {
 	acc.mutation.SetID(u)
@@ -115,7 +129,9 @@ func (acc *AppConfigCreate) Mutation() *AppConfigMutation {
 
 // Save creates the AppConfig in the database.
 func (acc *AppConfigCreate) Save(ctx context.Context) (*AppConfig, error) {
-	acc.defaults()
+	if err := acc.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, acc.sqlSave, acc.mutation, acc.hooks)
 }
 
@@ -142,12 +158,18 @@ func (acc *AppConfigCreate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (acc *AppConfigCreate) defaults() {
+func (acc *AppConfigCreate) defaults() error {
 	if _, ok := acc.mutation.CreatedAt(); !ok {
+		if appconfig.DefaultCreatedAt == nil {
+			return fmt.Errorf("ent: uninitialized appconfig.DefaultCreatedAt (forgotten import ent/runtime?)")
+		}
 		v := appconfig.DefaultCreatedAt()
 		acc.mutation.SetCreatedAt(v)
 	}
 	if _, ok := acc.mutation.UpdatedAt(); !ok {
+		if appconfig.DefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized appconfig.DefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := appconfig.DefaultUpdatedAt()
 		acc.mutation.SetUpdatedAt(v)
 	}
@@ -155,6 +177,11 @@ func (acc *AppConfigCreate) defaults() {
 		v := appconfig.DefaultStack
 		acc.mutation.SetStack(v)
 	}
+	if _, ok := acc.mutation.Source(); !ok {
+		v := appconfig.DefaultSource
+		acc.mutation.SetSource(v)
+	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -179,6 +206,14 @@ func (acc *AppConfigCreate) check() error {
 	}
 	if _, ok := acc.mutation.Value(); !ok {
 		return &ValidationError{Name: "value", err: errors.New(`ent: missing required field "AppConfig.value"`)}
+	}
+	if _, ok := acc.mutation.Source(); !ok {
+		return &ValidationError{Name: "source", err: errors.New(`ent: missing required field "AppConfig.source"`)}
+	}
+	if v, ok := acc.mutation.Source(); ok {
+		if err := appconfig.SourceValidator(v); err != nil {
+			return &ValidationError{Name: "source", err: fmt.Errorf(`ent: validator failed for field "AppConfig.source": %w`, err)}
+		}
 	}
 	return nil
 }
@@ -244,6 +279,10 @@ func (acc *AppConfigCreate) createSpec() (*AppConfig, *sqlgraph.CreateSpec) {
 	if value, ok := acc.mutation.Value(); ok {
 		_spec.SetField(appconfig.FieldValue, field.TypeString, value)
 		_node.Value = value
+	}
+	if value, ok := acc.mutation.Source(); ok {
+		_spec.SetField(appconfig.FieldSource, field.TypeEnum, value)
+		_node.Source = value
 	}
 	return _node, _spec
 }
@@ -384,6 +423,18 @@ func (u *AppConfigUpsert) SetValue(v string) *AppConfigUpsert {
 // UpdateValue sets the "value" field to the value that was provided on create.
 func (u *AppConfigUpsert) UpdateValue() *AppConfigUpsert {
 	u.SetExcluded(appconfig.FieldValue)
+	return u
+}
+
+// SetSource sets the "source" field.
+func (u *AppConfigUpsert) SetSource(v appconfig.Source) *AppConfigUpsert {
+	u.Set(appconfig.FieldSource, v)
+	return u
+}
+
+// UpdateSource sets the "source" field to the value that was provided on create.
+func (u *AppConfigUpsert) UpdateSource() *AppConfigUpsert {
+	u.SetExcluded(appconfig.FieldSource)
 	return u
 }
 
@@ -540,6 +591,20 @@ func (u *AppConfigUpsertOne) SetValue(v string) *AppConfigUpsertOne {
 func (u *AppConfigUpsertOne) UpdateValue() *AppConfigUpsertOne {
 	return u.Update(func(s *AppConfigUpsert) {
 		s.UpdateValue()
+	})
+}
+
+// SetSource sets the "source" field.
+func (u *AppConfigUpsertOne) SetSource(v appconfig.Source) *AppConfigUpsertOne {
+	return u.Update(func(s *AppConfigUpsert) {
+		s.SetSource(v)
+	})
+}
+
+// UpdateSource sets the "source" field to the value that was provided on create.
+func (u *AppConfigUpsertOne) UpdateSource() *AppConfigUpsertOne {
+	return u.Update(func(s *AppConfigUpsert) {
+		s.UpdateSource()
 	})
 }
 
@@ -862,6 +927,20 @@ func (u *AppConfigUpsertBulk) SetValue(v string) *AppConfigUpsertBulk {
 func (u *AppConfigUpsertBulk) UpdateValue() *AppConfigUpsertBulk {
 	return u.Update(func(s *AppConfigUpsert) {
 		s.UpdateValue()
+	})
+}
+
+// SetSource sets the "source" field.
+func (u *AppConfigUpsertBulk) SetSource(v appconfig.Source) *AppConfigUpsertBulk {
+	return u.Update(func(s *AppConfigUpsert) {
+		s.SetSource(v)
+	})
+}
+
+// UpdateSource sets the "source" field to the value that was provided on create.
+func (u *AppConfigUpsertBulk) UpdateSource() *AppConfigUpsertBulk {
+	return u.Update(func(s *AppConfigUpsert) {
+		s.UpdateSource()
 	})
 }
 

--- a/api/pkg/ent/appconfig_update.go
+++ b/api/pkg/ent/appconfig_update.go
@@ -92,6 +92,20 @@ func (acu *AppConfigUpdate) SetValue(s string) *AppConfigUpdate {
 	return acu
 }
 
+// SetSource sets the "source" field.
+func (acu *AppConfigUpdate) SetSource(a appconfig.Source) *AppConfigUpdate {
+	acu.mutation.SetSource(a)
+	return acu
+}
+
+// SetNillableSource sets the "source" field if the given value is not nil.
+func (acu *AppConfigUpdate) SetNillableSource(a *appconfig.Source) *AppConfigUpdate {
+	if a != nil {
+		acu.SetSource(*a)
+	}
+	return acu
+}
+
 // Mutation returns the AppConfigMutation object of the builder.
 func (acu *AppConfigUpdate) Mutation() *AppConfigMutation {
 	return acu.mutation
@@ -99,7 +113,9 @@ func (acu *AppConfigUpdate) Mutation() *AppConfigMutation {
 
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (acu *AppConfigUpdate) Save(ctx context.Context) (int, error) {
-	acu.defaults()
+	if err := acu.defaults(); err != nil {
+		return 0, err
+	}
 	return withHooks(ctx, acu.sqlSave, acu.mutation, acu.hooks)
 }
 
@@ -126,14 +142,31 @@ func (acu *AppConfigUpdate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (acu *AppConfigUpdate) defaults() {
+func (acu *AppConfigUpdate) defaults() error {
 	if _, ok := acu.mutation.UpdatedAt(); !ok {
+		if appconfig.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized appconfig.UpdateDefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := appconfig.UpdateDefaultUpdatedAt()
 		acu.mutation.SetUpdatedAt(v)
 	}
+	return nil
+}
+
+// check runs all checks and user-defined validators on the builder.
+func (acu *AppConfigUpdate) check() error {
+	if v, ok := acu.mutation.Source(); ok {
+		if err := appconfig.SourceValidator(v); err != nil {
+			return &ValidationError{Name: "source", err: fmt.Errorf(`ent: validator failed for field "AppConfig.source": %w`, err)}
+		}
+	}
+	return nil
 }
 
 func (acu *AppConfigUpdate) sqlSave(ctx context.Context) (n int, err error) {
+	if err := acu.check(); err != nil {
+		return n, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(appconfig.Table, appconfig.Columns, sqlgraph.NewFieldSpec(appconfig.FieldID, field.TypeUint))
 	if ps := acu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -165,6 +198,9 @@ func (acu *AppConfigUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := acu.mutation.Value(); ok {
 		_spec.SetField(appconfig.FieldValue, field.TypeString, value)
+	}
+	if value, ok := acu.mutation.Source(); ok {
+		_spec.SetField(appconfig.FieldSource, field.TypeEnum, value)
 	}
 	if n, err = sqlgraph.UpdateNodes(ctx, acu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
@@ -250,6 +286,20 @@ func (acuo *AppConfigUpdateOne) SetValue(s string) *AppConfigUpdateOne {
 	return acuo
 }
 
+// SetSource sets the "source" field.
+func (acuo *AppConfigUpdateOne) SetSource(a appconfig.Source) *AppConfigUpdateOne {
+	acuo.mutation.SetSource(a)
+	return acuo
+}
+
+// SetNillableSource sets the "source" field if the given value is not nil.
+func (acuo *AppConfigUpdateOne) SetNillableSource(a *appconfig.Source) *AppConfigUpdateOne {
+	if a != nil {
+		acuo.SetSource(*a)
+	}
+	return acuo
+}
+
 // Mutation returns the AppConfigMutation object of the builder.
 func (acuo *AppConfigUpdateOne) Mutation() *AppConfigMutation {
 	return acuo.mutation
@@ -270,7 +320,9 @@ func (acuo *AppConfigUpdateOne) Select(field string, fields ...string) *AppConfi
 
 // Save executes the query and returns the updated AppConfig entity.
 func (acuo *AppConfigUpdateOne) Save(ctx context.Context) (*AppConfig, error) {
-	acuo.defaults()
+	if err := acuo.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, acuo.sqlSave, acuo.mutation, acuo.hooks)
 }
 
@@ -297,14 +349,31 @@ func (acuo *AppConfigUpdateOne) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (acuo *AppConfigUpdateOne) defaults() {
+func (acuo *AppConfigUpdateOne) defaults() error {
 	if _, ok := acuo.mutation.UpdatedAt(); !ok {
+		if appconfig.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized appconfig.UpdateDefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := appconfig.UpdateDefaultUpdatedAt()
 		acuo.mutation.SetUpdatedAt(v)
 	}
+	return nil
+}
+
+// check runs all checks and user-defined validators on the builder.
+func (acuo *AppConfigUpdateOne) check() error {
+	if v, ok := acuo.mutation.Source(); ok {
+		if err := appconfig.SourceValidator(v); err != nil {
+			return &ValidationError{Name: "source", err: fmt.Errorf(`ent: validator failed for field "AppConfig.source": %w`, err)}
+		}
+	}
+	return nil
 }
 
 func (acuo *AppConfigUpdateOne) sqlSave(ctx context.Context) (_node *AppConfig, err error) {
+	if err := acuo.check(); err != nil {
+		return _node, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(appconfig.Table, appconfig.Columns, sqlgraph.NewFieldSpec(appconfig.FieldID, field.TypeUint))
 	id, ok := acuo.mutation.ID()
 	if !ok {
@@ -353,6 +422,9 @@ func (acuo *AppConfigUpdateOne) sqlSave(ctx context.Context) (_node *AppConfig, 
 	}
 	if value, ok := acuo.mutation.Value(); ok {
 		_spec.SetField(appconfig.FieldValue, field.TypeString, value)
+	}
+	if value, ok := acuo.mutation.Source(); ok {
+		_spec.SetField(appconfig.FieldSource, field.TypeEnum, value)
 	}
 	_node = &AppConfig{config: acuo.config}
 	_spec.Assign = _node.assignValues

--- a/api/pkg/ent/client.go
+++ b/api/pkg/ent/client.go
@@ -301,7 +301,8 @@ func (c *AppConfigClient) GetX(ctx context.Context, id uint) *AppConfig {
 
 // Hooks returns the client hooks.
 func (c *AppConfigClient) Hooks() []Hook {
-	return c.hooks.AppConfig
+	hooks := c.hooks.AppConfig
+	return append(hooks[:len(hooks):len(hooks)], appconfig.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.

--- a/api/pkg/ent/migrate/schema.go
+++ b/api/pkg/ent/migrate/schema.go
@@ -19,6 +19,7 @@ var (
 		{Name: "stack", Type: field.TypeString, Default: ""},
 		{Name: "key", Type: field.TypeString},
 		{Name: "value", Type: field.TypeString, Size: 2147483647},
+		{Name: "source", Type: field.TypeEnum, Enums: []string{"stack", "environment"}, Default: "environment"},
 	}
 	// AppConfigsTable holds the schema information for the "app_configs" table.
 	AppConfigsTable = &schema.Table{

--- a/api/pkg/ent/mutation.go
+++ b/api/pkg/ent/mutation.go
@@ -41,6 +41,7 @@ type AppConfigMutation struct {
 	stack         *string
 	key           *string
 	value         *string
+	source        *appconfig.Source
 	clearedFields map[string]struct{}
 	done          bool
 	oldValue      func(context.Context) (*AppConfig, error)
@@ -452,6 +453,42 @@ func (m *AppConfigMutation) ResetValue() {
 	m.value = nil
 }
 
+// SetSource sets the "source" field.
+func (m *AppConfigMutation) SetSource(a appconfig.Source) {
+	m.source = &a
+}
+
+// Source returns the value of the "source" field in the mutation.
+func (m *AppConfigMutation) Source() (r appconfig.Source, exists bool) {
+	v := m.source
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSource returns the old "source" field's value of the AppConfig entity.
+// If the AppConfig object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AppConfigMutation) OldSource(ctx context.Context) (v appconfig.Source, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSource is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSource requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSource: %w", err)
+	}
+	return oldValue.Source, nil
+}
+
+// ResetSource resets all changes to the "source" field.
+func (m *AppConfigMutation) ResetSource() {
+	m.source = nil
+}
+
 // Where appends a list predicates to the AppConfigMutation builder.
 func (m *AppConfigMutation) Where(ps ...predicate.AppConfig) {
 	m.predicates = append(m.predicates, ps...)
@@ -486,7 +523,7 @@ func (m *AppConfigMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AppConfigMutation) Fields() []string {
-	fields := make([]string, 0, 8)
+	fields := make([]string, 0, 9)
 	if m.created_at != nil {
 		fields = append(fields, appconfig.FieldCreatedAt)
 	}
@@ -510,6 +547,9 @@ func (m *AppConfigMutation) Fields() []string {
 	}
 	if m.value != nil {
 		fields = append(fields, appconfig.FieldValue)
+	}
+	if m.source != nil {
+		fields = append(fields, appconfig.FieldSource)
 	}
 	return fields
 }
@@ -535,6 +575,8 @@ func (m *AppConfigMutation) Field(name string) (ent.Value, bool) {
 		return m.Key()
 	case appconfig.FieldValue:
 		return m.Value()
+	case appconfig.FieldSource:
+		return m.Source()
 	}
 	return nil, false
 }
@@ -560,6 +602,8 @@ func (m *AppConfigMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldKey(ctx)
 	case appconfig.FieldValue:
 		return m.OldValue(ctx)
+	case appconfig.FieldSource:
+		return m.OldSource(ctx)
 	}
 	return nil, fmt.Errorf("unknown AppConfig field %s", name)
 }
@@ -624,6 +668,13 @@ func (m *AppConfigMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetValue(v)
+		return nil
+	case appconfig.FieldSource:
+		v, ok := value.(appconfig.Source)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSource(v)
 		return nil
 	}
 	return fmt.Errorf("unknown AppConfig field %s", name)
@@ -706,6 +757,9 @@ func (m *AppConfigMutation) ResetField(name string) error {
 		return nil
 	case appconfig.FieldValue:
 		m.ResetValue()
+		return nil
+	case appconfig.FieldSource:
+		m.ResetSource()
 		return nil
 	}
 	return fmt.Errorf("unknown AppConfig field %s", name)

--- a/api/pkg/ent/runtime.go
+++ b/api/pkg/ent/runtime.go
@@ -2,31 +2,4 @@
 
 package ent
 
-import (
-	"time"
-
-	"github.com/chanzuckerberg/happy/api/pkg/ent/appconfig"
-	"github.com/chanzuckerberg/happy/api/pkg/ent/schema"
-)
-
-// The init function reads all schema descriptors with runtime code
-// (default values, validators, hooks and policies) and stitches it
-// to their package variables.
-func init() {
-	appconfigFields := schema.AppConfig{}.Fields()
-	_ = appconfigFields
-	// appconfigDescCreatedAt is the schema descriptor for created_at field.
-	appconfigDescCreatedAt := appconfigFields[1].Descriptor()
-	// appconfig.DefaultCreatedAt holds the default value on creation for the created_at field.
-	appconfig.DefaultCreatedAt = appconfigDescCreatedAt.Default.(func() time.Time)
-	// appconfigDescUpdatedAt is the schema descriptor for updated_at field.
-	appconfigDescUpdatedAt := appconfigFields[2].Descriptor()
-	// appconfig.DefaultUpdatedAt holds the default value on creation for the updated_at field.
-	appconfig.DefaultUpdatedAt = appconfigDescUpdatedAt.Default.(func() time.Time)
-	// appconfig.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
-	appconfig.UpdateDefaultUpdatedAt = appconfigDescUpdatedAt.UpdateDefault.(func() time.Time)
-	// appconfigDescStack is the schema descriptor for stack field.
-	appconfigDescStack := appconfigFields[6].Descriptor()
-	// appconfig.DefaultStack holds the default value on creation for the stack field.
-	appconfig.DefaultStack = appconfigDescStack.Default.(string)
-}
+// The schema-stitching logic is generated in github.com/chanzuckerberg/happy/api/pkg/ent/runtime/runtime.go

--- a/api/pkg/ent/runtime/runtime.go
+++ b/api/pkg/ent/runtime/runtime.go
@@ -2,7 +2,36 @@
 
 package runtime
 
-// The schema-stitching logic is generated in github.com/chanzuckerberg/happy/api/pkg/ent/runtime.go
+import (
+	"time"
+
+	"github.com/chanzuckerberg/happy/api/pkg/ent/appconfig"
+	"github.com/chanzuckerberg/happy/api/pkg/ent/schema"
+)
+
+// The init function reads all schema descriptors with runtime code
+// (default values, validators, hooks and policies) and stitches it
+// to their package variables.
+func init() {
+	appconfigHooks := schema.AppConfig{}.Hooks()
+	appconfig.Hooks[0] = appconfigHooks[0]
+	appconfigFields := schema.AppConfig{}.Fields()
+	_ = appconfigFields
+	// appconfigDescCreatedAt is the schema descriptor for created_at field.
+	appconfigDescCreatedAt := appconfigFields[1].Descriptor()
+	// appconfig.DefaultCreatedAt holds the default value on creation for the created_at field.
+	appconfig.DefaultCreatedAt = appconfigDescCreatedAt.Default.(func() time.Time)
+	// appconfigDescUpdatedAt is the schema descriptor for updated_at field.
+	appconfigDescUpdatedAt := appconfigFields[2].Descriptor()
+	// appconfig.DefaultUpdatedAt holds the default value on creation for the updated_at field.
+	appconfig.DefaultUpdatedAt = appconfigDescUpdatedAt.Default.(func() time.Time)
+	// appconfig.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
+	appconfig.UpdateDefaultUpdatedAt = appconfigDescUpdatedAt.UpdateDefault.(func() time.Time)
+	// appconfigDescStack is the schema descriptor for stack field.
+	appconfigDescStack := appconfigFields[6].Descriptor()
+	// appconfig.DefaultStack holds the default value on creation for the stack field.
+	appconfig.DefaultStack = appconfigDescStack.Default.(string)
+}
 
 const (
 	Version = "v0.12.4"                                         // Version of ent codegen.

--- a/api/pkg/ent/schema/appconfig.go
+++ b/api/pkg/ent/schema/appconfig.go
@@ -1,11 +1,15 @@
 package schema
 
 import (
+	"context"
 	"time"
 
 	"entgo.io/ent"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
+	gen "github.com/chanzuckerberg/happy/api/pkg/ent"
+	"github.com/chanzuckerberg/happy/api/pkg/ent/appconfig"
+	"github.com/chanzuckerberg/happy/api/pkg/ent/hook"
 )
 
 type AppConfig struct {
@@ -41,11 +45,11 @@ func (AppConfig) Fields() []ent.Field {
 			String("key"),
 		field.
 			Text("value"),
-		// field.
-		// 	Enum("source").
-		// 	Values("stack", "environment").
-		// 	Default("environment").
-		// 	Comment("'stack' if the config is for a specific stack or 'environment' if available to all stacks in the environment"),
+		field.
+			Enum("source").
+			Values("stack", "environment").
+			Default("environment").
+			Comment("'stack' if the config is for a specific stack or 'environment' if available to all stacks in the environment"),
 	}
 }
 
@@ -66,15 +70,15 @@ func (AppConfig) Edges() []ent.Edge {
 func (AppConfig) Hooks() []ent.Hook {
 	return []ent.Hook{
 		// hook to populate the source field
-		// func(next ent.Mutator) ent.Mutator {
-		// 	return hook.AppConfigFunc(func(ctx context.Context, m *gen.AppConfigMutation) (ent.Value, error) {
-		// 		source := appconfig.SourceEnvironment
-		// 		if stack, ok := m.Stack(); ok && stack != "" {
-		// 			source = appconfig.SourceStack
-		// 		}
-		// 		m.SetSource(source)
-		// 		return next.Mutate(ctx, m)
-		// 	})
-		// },
+		func(next ent.Mutator) ent.Mutator {
+			return hook.AppConfigFunc(func(ctx context.Context, m *gen.AppConfigMutation) (ent.Value, error) {
+				source := appconfig.SourceEnvironment
+				if stack, ok := m.Stack(); ok && stack != "" {
+					source = appconfig.SourceStack
+				}
+				m.SetSource(source)
+				return next.Mutate(ctx, m)
+			})
+		},
 	}
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-1995:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-1995" title="CCIE-1995" target="_blank">CCIE-1995</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Add source column to Happy API app_configs table</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-1995

Adds a `source` column to the app_configs table along with a hook to populate it, allowing us to stop doing the separate logic where we resolve the source at runtime