### PR TITLE
feat: allow AWS account ID to change for ECR policy

### DIFF
--- a/terraform/modules/happy-github-ci-role/README.md
+++ b/terraform/modules/happy-github-ci-role/README.md
@@ -38,6 +38,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The account ID of the ECR you want to grant access to | `string` | `""` | no |
 | <a name="input_dynamodb_table_arn"></a> [dynamodb\_table\_arn](#input\_dynamodb\_table\_arn) | The ARN of the dynamodb table that the role should have permissions to | `string` | n/a | yes |
 | <a name="input_ecrs"></a> [ecrs](#input\_ecrs) | The ECRs that the role should have permissions to | <pre>map(object({<br>    repository_arn : string,<br>  }))</pre> | `{}` | no |
 | <a name="input_ecs"></a> [ecs](#input\_ecs) | The ARN and happy app name of the ECS cluster that the role should have permissions to | <pre>object({<br>    arn            = string<br>    happy_app_name = string<br>  })</pre> | <pre>{<br>  "arn": "",<br>  "happy_app_name": ""<br>}</pre> | no |

--- a/terraform/modules/happy-github-ci-role/ecr.tf
+++ b/terraform/modules/happy-github-ci-role/ecr.tf
@@ -1,5 +1,9 @@
 data "aws_caller_identity" "current" {}
 
+local {
+  account_id = var.aws_account_id == "" ? data.aws_caller_identity.current.account_id : var.aws_account_id
+}
+
 resource "random_pet" "this" {
   keepers = {
     role_name = var.gh_actions_role_name
@@ -24,7 +28,7 @@ module "autocreated_ecr_writer_policy" {
   source    = "git@github.com:chanzuckerberg/shared-infra//terraform/modules/aws-iam-policy-ecr-writer?ref=v0.125.0"
   role_name = var.gh_actions_role_name
   // TODO: not a super fan of this. Would be ideal to have the role only have access to the stacks created by this happy project
-  ecr_repository_arns = ["arn:aws:ecr:us-west-2:${data.aws_caller_identity.current.account_id}:repository/*/${var.tags.env}/*"]
+  ecr_repository_arns = ["arn:aws:ecr:us-west-2:${local.account_id}:repository/*/${var.tags.env}/*"]
   policy_name         = "gh_actions_ecr_push_${random_pet.this.id}"
 
   project = var.tags.project

--- a/terraform/modules/happy-github-ci-role/variables.tf
+++ b/terraform/modules/happy-github-ci-role/variables.tf
@@ -41,3 +41,9 @@ variable "ecs" {
   })
   default = { arn = "", happy_app_name = "" }
 }
+
+variable "aws_account_id" {
+  description = "The account ID of the ECR you want to grant access to"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2010:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2010" title="CCIE-2010" target="_blank">CCIE-2010</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Allow module to be used across AWS accounts</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-2010?atlOrigin=eyJpIjoiNDg5ODEyMzVlMWRkNGUxMmI0Zjc2NjJiNzNiZmY0YjkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

This allows the caller to change the AWS account that the ECR lives in. If nothing is specified, it will use the current account that it i s being executed. This is helpful when we need to grant one CI role access to other happy environments.