### PR TITLE
fix: Do not create a pod disruption budget for deployment with the desired_count=max_unavailable_count

### DIFF
--- a/terraform/modules/happy-service-eks/main.tf
+++ b/terraform/modules/happy-service-eks/main.tf
@@ -521,7 +521,7 @@ resource "kubernetes_horizontal_pod_autoscaler_v1" "hpa" {
 }
 
 resource "kubernetes_pod_disruption_budget_v1" "pdb" {
-  count = var.routing.service_type == "IMAGE_TEMPLATE" ? 0 : 1
+  count = var.routing.service_type == "IMAGE_TEMPLATE" && var.max_unavailable_count > var.desired_count ? 0 : 1
   metadata {
     name      = var.routing.service_name
     namespace = var.k8s_namespace

--- a/terraform/modules/happy-service-eks/main.tf
+++ b/terraform/modules/happy-service-eks/main.tf
@@ -521,7 +521,7 @@ resource "kubernetes_horizontal_pod_autoscaler_v1" "hpa" {
 }
 
 resource "kubernetes_pod_disruption_budget_v1" "pdb" {
-  count = var.routing.service_type == "IMAGE_TEMPLATE" && var.max_unavailable_count < var.desired_count ? 0 : 1
+  count = var.routing.service_type == "IMAGE_TEMPLATE" && var.max_unavailable_count >= var.desired_count ? 0 : 1
   metadata {
     name      = var.routing.service_name
     namespace = var.k8s_namespace

--- a/terraform/modules/happy-service-eks/main.tf
+++ b/terraform/modules/happy-service-eks/main.tf
@@ -521,7 +521,7 @@ resource "kubernetes_horizontal_pod_autoscaler_v1" "hpa" {
 }
 
 resource "kubernetes_pod_disruption_budget_v1" "pdb" {
-  count = var.routing.service_type == "IMAGE_TEMPLATE" && var.max_unavailable_count > var.desired_count ? 0 : 1
+  count = var.routing.service_type == "IMAGE_TEMPLATE" && var.max_unavailable_count < var.desired_count ? 0 : 1
   metadata {
     name      = var.routing.service_name
     namespace = var.k8s_namespace

--- a/terraform/modules/happy-service-eks/main.tf
+++ b/terraform/modules/happy-service-eks/main.tf
@@ -521,7 +521,7 @@ resource "kubernetes_horizontal_pod_autoscaler_v1" "hpa" {
 }
 
 resource "kubernetes_pod_disruption_budget_v1" "pdb" {
-  count = var.routing.service_type == "IMAGE_TEMPLATE" && var.max_unavailable_count >= var.desired_count ? 0 : 1
+  count = var.routing.service_type == "IMAGE_TEMPLATE" || var.max_unavailable_count >= var.desired_count ? 0 : 1
   metadata {
     name      = var.routing.service_name
     namespace = var.k8s_namespace


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2061:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2061" title="CCIE-2061" target="_blank">CCIE-2061</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy: When pod disruption budget is set of 1-pod deployments it blocks rotation of EKS nodes</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-2061]

[CCIE-2061]: https://czi-tech.atlassian.net/browse/CCIE-2061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ