### PR TITLE
fix: redirect HTTP traffic to HTTPS from viewer to CloudFront

### DIFF
--- a/terraform/modules/happy-cloudfront/main.tf
+++ b/terraform/modules/happy-cloudfront/main.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   default_cache_behavior {
-    viewer_protocol_policy   = "https-only"
+    viewer_protocol_policy   = "redirect-to-https"
     target_origin_id         = local.origin_id
     allowed_methods          = var.cache_allowed_methods
     cached_methods           = var.cache_allowed_methods


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2070:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2070" title="CCIE-2070" target="_blank">CCIE-2070</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>CloudFront Happy Stacks Not Redirecting to HTTPS</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-2070?atlOrigin=eyJpIjoiY2RkNjJlYTcyZDE2NDZlNmExYThjZTFiNTg3MTRhOTMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## Summary

This PR fixes a bug where the default configuration of CloudFront was to only allow HTTPS traffic. While that is the behavior we want, we want to redirect all HTTP traffic to the HTTPS endpoint, not just block HTTP traffic.

