### PR TITLE
feat: separate configuration of allow methods and allowed cache methods

### DIFF
--- a/terraform/modules/happy-cloudfront/README.md
+++ b/terraform/modules/happy-cloudfront/README.md
@@ -33,8 +33,9 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allowed_methods"></a> [allowed\_methods](#input\_allowed\_methods) | The allowed methods for the CloudFront distribution. | `set(string)` | <pre>[<br>  "DELETE",<br>  "GET",<br>  "HEAD",<br>  "OPTIONS",<br>  "PATCH",<br>  "POST",<br>  "PUT"<br>]</pre> | no |
 | <a name="input_cache"></a> [cache](#input\_cache) | The cache settings for the CloudFront distribution. | <pre>object({<br>    min_ttl     = optional(number, 0)<br>    default_ttl = optional(number, 300)<br>    max_ttl     = optional(number, 300)<br>    compress    = optional(bool, true)<br>  })</pre> | `{}` | no |
-| <a name="input_cache_allowed_methods"></a> [cache\_allowed\_methods](#input\_cache\_allowed\_methods) | The allowed methods for the CloudFront distribution. | `set(string)` | <pre>[<br>  "GET",<br>  "HEAD"<br>]</pre> | no |
+| <a name="input_cache_allowed_methods"></a> [cache\_allowed\_methods](#input\_cache\_allowed\_methods) | The allowed cache methods for the CloudFront distribution. | `set(string)` | <pre>[<br>  "GET",<br>  "HEAD"<br>]</pre> | no |
 | <a name="input_cache_policy_id"></a> [cache\_policy\_id](#input\_cache\_policy\_id) | The cache policy ID for the CloudFront distribution. | `string` | `"4135ea2d-6df8-44a3-9df3-4b5a84be39ad"` | no |
 | <a name="input_frontend"></a> [frontend](#input\_frontend) | The domain name and zone ID the user will see. | <pre>object({<br>    domain_name = string<br>    zone_id     = string<br>  })</pre> | n/a | yes |
 | <a name="input_geo_restriction_locations"></a> [geo\_restriction\_locations](#input\_geo\_restriction\_locations) | The countries to whitelist for the CloudFront distribution. | `set(string)` | <pre>[<br>  "US"<br>]</pre> | no |

--- a/terraform/modules/happy-cloudfront/README.md
+++ b/terraform/modules/happy-cloudfront/README.md
@@ -33,7 +33,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_methods"></a> [allowed\_methods](#input\_allowed\_methods) | The allowed methods for the CloudFront distribution. | `set(string)` | <pre>[<br>  "DELETE",<br>  "GET",<br>  "HEAD",<br>  "OPTIONS",<br>  "PATCH",<br>  "POST",<br>  "PUT"<br>]</pre> | no |
+| <a name="input_allowed_methods"></a> [allowed\_methods](#input\_allowed\_methods) | The allowed HTTP methods for the CloudFront distribution. | `set(string)` | <pre>[<br>  "DELETE",<br>  "GET",<br>  "HEAD",<br>  "OPTIONS",<br>  "PATCH",<br>  "POST",<br>  "PUT"<br>]</pre> | no |
 | <a name="input_cache"></a> [cache](#input\_cache) | The cache settings for the CloudFront distribution. | <pre>object({<br>    min_ttl     = optional(number, 0)<br>    default_ttl = optional(number, 300)<br>    max_ttl     = optional(number, 300)<br>    compress    = optional(bool, true)<br>  })</pre> | `{}` | no |
 | <a name="input_cache_allowed_methods"></a> [cache\_allowed\_methods](#input\_cache\_allowed\_methods) | The allowed cache methods for the CloudFront distribution. | `set(string)` | <pre>[<br>  "GET",<br>  "HEAD"<br>]</pre> | no |
 | <a name="input_cache_policy_id"></a> [cache\_policy\_id](#input\_cache\_policy\_id) | The cache policy ID for the CloudFront distribution. | `string` | `"4135ea2d-6df8-44a3-9df3-4b5a84be39ad"` | no |

--- a/terraform/modules/happy-cloudfront/main.tf
+++ b/terraform/modules/happy-cloudfront/main.tf
@@ -47,7 +47,7 @@ resource "aws_cloudfront_distribution" "this" {
   default_cache_behavior {
     viewer_protocol_policy   = "redirect-to-https"
     target_origin_id         = local.origin_id
-    allowed_methods          = var.cache_allowed_methods
+    allowed_methods          = var.allowed_methods
     cached_methods           = var.cache_allowed_methods
     origin_request_policy_id = var.origin_request_policy_id
     cache_policy_id          = var.cache_policy_id

--- a/terraform/modules/happy-cloudfront/variables.tf
+++ b/terraform/modules/happy-cloudfront/variables.tf
@@ -39,7 +39,7 @@ variable "cache_allowed_methods" {
 variable "allowed_methods" {
   type        = set(string)
   default     = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-  description = "The allowed methods for the CloudFront distribution."
+  description = "The allowed HTTP methods for the CloudFront distribution."
 }
 
 variable "origin_request_policy_id" {

--- a/terraform/modules/happy-cloudfront/variables.tf
+++ b/terraform/modules/happy-cloudfront/variables.tf
@@ -33,6 +33,12 @@ variable "geo_restriction_locations" {
 variable "cache_allowed_methods" {
   type        = set(string)
   default     = ["GET", "HEAD"]
+  description = "The allowed cache methods for the CloudFront distribution."
+}
+
+variable "allowed_methods" {
+  type        = set(string)
+  default     = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
   description = "The allowed methods for the CloudFront distribution."
 }
 


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2075:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2075" title="CCIE-2075" target="_blank">CCIE-2075</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Allow POST in cloudfront for Happy</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Is this used by anyone other than ITBS?  I'm changing the default behavior here.

CCIE-2075