### PR TITLE
fix: Wait for the pods to appear before failing when migration job runs

### DIFF
--- a/shared/backend/aws/k8s_compute_backend.go
+++ b/shared/backend/aws/k8s_compute_backend.go
@@ -229,10 +229,12 @@ func (k8s *K8SComputeBackend) RunTask(ctx context.Context, taskDefArn string, la
 	if err != nil {
 		return errors.Wrap(err, "unable to create a k8s job")
 	}
+	logrus.Infof("Created a k8s job '%s'", jobId)
 
-	// TODO: Wait for job to finish, fail, or time out
+	timeout := int64(600)
 	watch, err := k8s.ClientSet.BatchV1().Jobs(k8s.KubeConfig.Namespace).Watch(ctx, v1.ListOptions{
-		FieldSelector: "metadata.name=" + jobId,
+		FieldSelector:  "metadata.name=" + jobId,
+		TimeoutSeconds: &timeout,
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to start a k8s job watch")
@@ -297,7 +299,7 @@ func (k8s *K8SComputeBackend) RunTask(ctx context.Context, taskDefArn string, la
 		}
 
 		return pods, nil
-	}, 30*time.Second, 10*time.Minute)
+	}, 10*time.Second, 2*time.Minute)
 
 	if err != nil {
 		return errors.Wrap(err, "pods did not successfuly start on time")


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2083:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2083" title="CCIE-2083" target="_blank">CCIE-2083</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy: Wait for the pods to appear before failing when migration job runs</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

null