### PR TITLE
fix: CCIE-2089: Make happy addtags command help clearer

### DIFF
--- a/cli/cmd/tags.go
+++ b/cli/cmd/tags.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 var tagsCmd = &cobra.Command{
-	Use:          "addtags",
+	Use:          "addtags <stack-name>",
 	Short:        "Add additional tags to already-pushed images in the ECR repo",
 	Long:         "Add additional tags to already-pushed images in the ECR repo",
 	SilenceUsage: true,


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2089:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2089" title="CCIE-2089" target="_blank">CCIE-2089</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>On-Call: Happy: Make addtags command help clearer</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

null