### PR TITLE
fix: Fix helm chart release regex

### DIFF
--- a/.github/workflows/charts-release.yml
+++ b/.github/workflows/charts-release.yml
@@ -103,7 +103,8 @@ jobs:
           
           RELEASE=${{ needs.check-chart-released.outputs.tag }}
           VERSION=${{ steps.parse_version.outputs.result }}
-          sed -i "\d+\.\d+\.\d+/$VERSION/g" ${CHARTS_DIR}/Chart.yaml
+          sed -i 's/appVersion\:\s[0-9.]\+/appVersion\: ${VERSION}/g' ${CHARTS_DIR}/Chart.yaml
+          sed -i 's/version\:\s[0-9.]\+/version\: ${VERSION}/g' ${CHARTS_DIR}/Chart.yaml
           echo ------
           cat ${CHARTS_DIR}/Chart.yaml
           echo ------


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2108:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2108" title="CCIE-2108" target="_blank">CCIE-2108</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Fix the helm chart release process</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-2108]

[CCIE-2108]: https://czi-tech.atlassian.net/browse/CCIE-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ