### PR TITLE
fix: Happy validations fail when an app folder is not version controlled

### DIFF
--- a/shared/util/github.go
+++ b/shared/util/github.go
@@ -84,7 +84,8 @@ func IsCleanGitTree(dir string) (bool, *git.Status, error) {
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err != nil {
-		return false, nil, errors.Wrapf(err, "error running %s", cmd.String())
+		logrus.Errorf("unable to execute '%s', is this folder under source control?", err.Error())
+		return true, nil, nil
 	}
 	r, err := git.PlainOpen(strings.Trim(out.String(), "\n"))
 	if err != nil {

--- a/shared/util/github.go
+++ b/shared/util/github.go
@@ -84,7 +84,7 @@ func IsCleanGitTree(dir string) (bool, *git.Status, error) {
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err != nil {
-		logrus.Errorf("unable to execute '%s', is this folder under source control?", err.Error())
+		logrus.Debugf("Folder %s is not under source control, or git is not installed", dir)
 		return true, nil, nil
 	}
 	r, err := git.PlainOpen(strings.Trim(out.String(), "\n"))


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2127:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2127" title="CCIE-2127" target="_blank">CCIE-2127</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy: Impossible to run happy commands when the app folder is not under source control</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-2127]

[CCIE-2127]: https://czi-tech.atlassian.net/browse/CCIE-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ