### PR TITLE
fix: implement root health handler

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -2,17 +2,13 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 	"time"
 
 	_ "github.com/chanzuckerberg/happy/api/docs" // import API docs
 	"github.com/chanzuckerberg/happy/api/pkg/api"
-	"github.com/chanzuckerberg/happy/api/pkg/request"
 	"github.com/chanzuckerberg/happy/api/pkg/setup"
 	"github.com/chanzuckerberg/happy/api/pkg/store"
 	sentry "github.com/getsentry/sentry-go"
-	"github.com/gofiber/fiber/v2/middleware/adaptor"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -42,30 +38,14 @@ func exec(ctx context.Context) error {
 	}
 
 	// run the DB migrations
-	err = store.MakeDB(cfg.Database).AutoMigrate()
+	db := store.MakeDB(cfg.Database)
+	err = db.AutoMigrate()
 	if err != nil {
 		logrus.Fatal(err)
 	}
 
-	// create a mux to route requests to the correct app
-	rootMux := http.NewServeMux()
-	rootMux.Handle("/", request.HealthHandler{})
-	rootMux.Handle("/health", request.HealthHandler{})
-	rootMux.Handle("/versionCheck", request.VersionCheckHandler{})
-
-	// create the Fiber app
-	app := api.MakeFiberApp(ctx, cfg)
-	nativeHandler := adaptor.FiberApp(app.FiberApp)
-	rootMux.Handle("/v1/", http.StripPrefix("/v1", nativeHandler))
-
-	// create the Ogent app
-	svr, err := api.MakeOgentServer(ctx, cfg)
-	if err != nil {
-		logrus.Fatal(err)
-	}
-	rootMux.Handle("/v2/", svr)
-
-	return http.ListenAndServe(fmt.Sprintf(":%d", cfg.Api.Port), rootMux)
+	app := api.MakeAPIApplication(ctx, cfg, db)
+	return app.Listen()
 }
 
 // @title       Happy API

--- a/api/main.go
+++ b/api/main.go
@@ -8,6 +8,7 @@ import (
 
 	_ "github.com/chanzuckerberg/happy/api/docs" // import API docs
 	"github.com/chanzuckerberg/happy/api/pkg/api"
+	"github.com/chanzuckerberg/happy/api/pkg/request"
 	"github.com/chanzuckerberg/happy/api/pkg/setup"
 	"github.com/chanzuckerberg/happy/api/pkg/store"
 	sentry "github.com/getsentry/sentry-go"
@@ -48,6 +49,9 @@ func exec(ctx context.Context) error {
 
 	// create a mux to route requests to the correct app
 	rootMux := http.NewServeMux()
+	rootMux.Handle("/", request.HealthHandler{})
+	rootMux.Handle("/health", request.HealthHandler{})
+	rootMux.Handle("/versionCheck", request.VersionCheckHandler{})
 
 	// create the Fiber app
 	app := api.MakeFiberApp(ctx, cfg)

--- a/api/pkg/api/app.go
+++ b/api/pkg/api/app.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/chanzuckerberg/happy/api/pkg/request"
+	"github.com/chanzuckerberg/happy/api/pkg/setup"
+	"github.com/chanzuckerberg/happy/api/pkg/store"
+	"github.com/gofiber/fiber/v2/middleware/adaptor"
+	"github.com/sirupsen/logrus"
+)
+
+type APIApplication struct {
+	cfg *setup.Configuration
+	mux *http.ServeMux
+	DB  *store.DB
+}
+
+func MakeAPIApplication(ctx context.Context, cfg *setup.Configuration, db *store.DB) *APIApplication {
+	// create a mux to route requests to the correct app
+	rootMux := http.NewServeMux()
+	rootMux.Handle("/", request.HealthHandler{})
+	rootMux.Handle("/health", request.HealthHandler{})
+	rootMux.Handle("/versionCheck", request.VersionCheckHandler{})
+
+	// create the Fiber app
+	app := MakeFiberApp(ctx, cfg, db)
+	nativeHandler := adaptor.FiberApp(app.FiberApp)
+	rootMux.Handle("/v1/", http.StripPrefix("/v1", nativeHandler))
+
+	// create the Ogent app
+	svr, err := MakeOgentServer(ctx, cfg, db)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	rootMux.Handle("/v2/", svr)
+
+	return &APIApplication{
+		cfg: cfg,
+		DB:  db,
+		mux: rootMux,
+	}
+}
+
+func (a *APIApplication) Listen() error {
+	return http.ListenAndServe(fmt.Sprintf(":%d", a.cfg.Api.Port), a.mux)
+}

--- a/api/pkg/api/app_ent.go
+++ b/api/pkg/api/app_ent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chanzuckerberg/happy/api/pkg/response"
 	"github.com/chanzuckerberg/happy/api/pkg/setup"
 	"github.com/chanzuckerberg/happy/api/pkg/store"
+	"github.com/chanzuckerberg/happy/shared/util"
 	sentryotel "github.com/getsentry/sentry-go/otel"
 	"github.com/go-faster/jx"
 	"github.com/pkg/errors"
@@ -21,8 +22,8 @@ type handler struct {
 	db *store.DB
 }
 
-func (h handler) Health(_ context.Context) (ogent.HealthRes, error) {
-	return &ogent.HealthOK{Status: "ok"}, nil
+func (h handler) Health(ctx context.Context) (ogent.HealthRes, error) {
+	return &ogent.HealthOK{Status: "OK", Version: util.ReleaseVersion, GitSha: util.ReleaseGitSha, Route: "/v2/health"}, nil
 }
 
 func (h handler) ListAppConfig(ctx context.Context, params ogent.ListAppConfigParams) (ogent.ListAppConfigRes, error) {
@@ -49,12 +50,7 @@ func (h handler) ReadAppConfig(ctx context.Context, params ogent.ReadAppConfigPa
 	return (ogent.ReadAppConfigRes)(r), nil
 }
 
-func MakeOgentServer(ctx context.Context, cfg *setup.Configuration) (*ogent.Server, error) {
-	db := store.MakeDB(cfg.Database)
-	return MakeOgentServerWithDB(ctx, cfg, db)
-}
-
-func MakeOgentServerWithDB(ctx context.Context, cfg *setup.Configuration, db *store.DB) (*ogent.Server, error) {
+func MakeOgentServer(ctx context.Context, cfg *setup.Configuration, db *store.DB) (*ogent.Server, error) {
 	middlewares := []ogent.Middleware{request.MakeOgentLoggerMiddleware(cfg)}
 	if *cfg.Auth.Enable {
 		verifier := request.MakeVerifierFromConfig(ctx, cfg)

--- a/api/pkg/api/app_ent_test.go
+++ b/api/pkg/api/app_ent_test.go
@@ -38,7 +38,7 @@ func TestHealthSucceed(t *testing.T) {
 	err = json.Unmarshal(body, &jsonBody)
 	r.NoError(err)
 
-	r.Contains(jsonBody["status"], "ok")
+	r.Contains(jsonBody["status"], "OK")
 }
 
 func TestAppConfigsFail(t *testing.T) {
@@ -70,9 +70,9 @@ func TestAppConfigsFail(t *testing.T) {
 
 			r.Equal(500, resp.StatusCode)
 
-			body, err := io.ReadAll(resp.Body)
+			bodyBytes, err := io.ReadAll(resp.Body)
 			r.NoError(err)
-			r.Equal(tc.errorResponse, body)
+			r.Equal(tc.errorResponse, string(bodyBytes))
 		})
 	}
 }

--- a/api/pkg/api/app_fiber.go
+++ b/api/pkg/api/app_fiber.go
@@ -49,7 +49,7 @@ func MakeAppWithDB(ctx context.Context, cfg *setup.Configuration, db *store.DB) 
 	}))
 	apiApp.configureLogger(cfg.Api)
 	apiApp.FiberApp.Use(func(c *fiber.Ctx) error {
-		err := request.VersionCheckHandler(c)
+		err := request.VersionCheckHandlerFiber(c)
 		if err != nil {
 			return err
 		}
@@ -59,13 +59,12 @@ func MakeAppWithDB(ctx context.Context, cfg *setup.Configuration, db *store.DB) 
 		return c.Next()
 	})
 
-	apiApp.FiberApp.Get("/", request.HealthHandler)
-	apiApp.FiberApp.Get("/health", request.HealthHandler)
-	apiApp.FiberApp.Get("/versionCheck", request.VersionCheckHandler)
-	apiApp.FiberApp.Get("/swagger/*", swagger.HandlerDefault)
-	apiApp.FiberApp.Get("/metrics", request.PrometheusMetricsHandler)
-
 	v1 := apiApp.FiberApp.Group("/v1")
+	v1.Get("/", request.HealthHandlerFiber)
+	v1.Get("/health", request.HealthHandlerFiber)
+	v1.Get("/swagger/*", swagger.HandlerDefault)
+	v1.Get("/metrics", request.PrometheusMetricsHandler)
+
 	if *cfg.Auth.Enable {
 		verifier := request.MakeVerifierFromConfig(ctx, cfg)
 		v1.Use(request.MakeFiberAuthMiddleware(verifier))

--- a/api/pkg/api/app_fiber.go
+++ b/api/pkg/api/app_fiber.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/chanzuckerberg/happy/api/pkg/cmd"
@@ -19,14 +18,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type APIApplication struct {
+type FiberServer struct {
 	FiberApp *fiber.App
 	DB       *store.DB
 	Cfg      *setup.Configuration
 }
 
-func MakeAPIApplication(cfg *setup.Configuration) *APIApplication {
-	return &APIApplication{
+func MakeFiberServer(cfg *setup.Configuration) *FiberServer {
+	return &FiberServer{
 		FiberApp: fiber.New(fiber.Config{
 			AppName:        "happy-api",
 			ReadTimeout:    60 * time.Second,
@@ -36,13 +35,8 @@ func MakeAPIApplication(cfg *setup.Configuration) *APIApplication {
 	}
 }
 
-func MakeFiberApp(ctx context.Context, cfg *setup.Configuration) *APIApplication {
-	db := store.MakeDB(cfg.Database)
-	return MakeAppWithDB(ctx, cfg, db)
-}
-
-func MakeAppWithDB(ctx context.Context, cfg *setup.Configuration, db *store.DB) *APIApplication {
-	apiApp := MakeAPIApplication(cfg).WithDatabase(db)
+func MakeFiberApp(ctx context.Context, cfg *setup.Configuration, db *store.DB) *FiberServer {
+	apiApp := MakeFiberServer(cfg).WithDatabase(db)
 	apiApp.FiberApp.Use(requestid.New())
 	apiApp.FiberApp.Use(cors.New(cors.Config{
 		AllowHeaders: "Authorization,Content-Type,x-aws-access-key-id,x-aws-secret-access-key,x-aws-session-token,baggage,sentry-trace",
@@ -60,7 +54,6 @@ func MakeAppWithDB(ctx context.Context, cfg *setup.Configuration, db *store.DB) 
 	})
 
 	v1 := apiApp.FiberApp.Group("/v1")
-	v1.Get("/", request.HealthHandlerFiber)
 	v1.Get("/health", request.HealthHandlerFiber)
 	v1.Get("/swagger/*", swagger.HandlerDefault)
 	v1.Get("/metrics", request.PrometheusMetricsHandler)
@@ -102,7 +95,7 @@ func MakeAppWithDB(ctx context.Context, cfg *setup.Configuration, db *store.DB) 
 	return apiApp
 }
 
-func (a *APIApplication) WithDatabase(db *store.DB) *APIApplication {
+func (a *FiberServer) WithDatabase(db *store.DB) *FiberServer {
 	a.DB = db
 	err := a.DB.AutoMigrate()
 	if err != nil {
@@ -111,7 +104,7 @@ func (a *APIApplication) WithDatabase(db *store.DB) *APIApplication {
 	return a
 }
 
-func (a *APIApplication) configureLogger(cfg setup.ApiConfiguration) {
+func (a *FiberServer) configureLogger(cfg setup.ApiConfiguration) {
 	if cfg.LogLevel == "silent" {
 		return
 	}
@@ -121,8 +114,4 @@ func (a *APIApplication) configureLogger(cfg setup.ApiConfiguration) {
 		TimeFormat: "2006-01-02T15:04:05-0700",
 		TimeZone:   "UTC",
 	}))
-}
-
-func (a *APIApplication) Listen() error {
-	return a.FiberApp.Listen(fmt.Sprintf(":%d", a.Cfg.Api.Port))
 }

--- a/api/pkg/api/config_group.go
+++ b/api/pkg/api/config_group.go
@@ -20,7 +20,7 @@ func MakeConfigHandler(c cmd.Config) *ConfigHandler {
 
 func RegisterConfigV1(v1 fiber.Router, baseHandler *ConfigHandler) {
 	group := v1.Group("/config")
-	group.Get("/health", request.HealthHandler)
+	group.Get("/health", request.HealthHandlerFiber)
 
 	// debugging endpoint that returns all config values for an app+env combo without resolving
 	group.Get("/dump", parseQueryString[model.AppMetadata], baseHandler.configDumpHandler)

--- a/api/pkg/ent/entc.go
+++ b/api/pkg/ent/entc.go
@@ -81,6 +81,9 @@ func main() {
 									SetType("object").
 									AddRequiredProperties(
 										ogen.String().ToProperty("status"),
+										ogen.String().ToProperty("route"),
+										ogen.String().ToProperty("version"),
+										ogen.String().ToProperty("git_sha"),
 									),
 							),
 					).

--- a/api/pkg/ent/ogent/oas_json_gen.go
+++ b/api/pkg/ent/ogent/oas_json_gen.go
@@ -316,10 +316,25 @@ func (s *HealthOK) encodeFields(e *jx.Encoder) {
 		e.FieldStart("status")
 		e.Str(s.Status)
 	}
+	{
+		e.FieldStart("route")
+		e.Str(s.Route)
+	}
+	{
+		e.FieldStart("version")
+		e.Str(s.Version)
+	}
+	{
+		e.FieldStart("git_sha")
+		e.Str(s.GitSha)
+	}
 }
 
-var jsonFieldsNameOfHealthOK = [1]string{
+var jsonFieldsNameOfHealthOK = [4]string{
 	0: "status",
+	1: "route",
+	2: "version",
+	3: "git_sha",
 }
 
 // Decode decodes HealthOK from json.
@@ -343,6 +358,42 @@ func (s *HealthOK) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"status\"")
 			}
+		case "route":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Route = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"route\"")
+			}
+		case "version":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.Version = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"version\"")
+			}
+		case "git_sha":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Str()
+				s.GitSha = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"git_sha\"")
+			}
 		default:
 			return d.Skip()
 		}
@@ -353,7 +404,7 @@ func (s *HealthOK) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00000001,
+		0b00001111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.

--- a/api/pkg/ent/ogent/oas_schemas_gen.go
+++ b/api/pkg/ent/ogent/oas_schemas_gen.go
@@ -167,7 +167,10 @@ func (s *AppConfigListSource) UnmarshalText(data []byte) error {
 }
 
 type HealthOK struct {
-	Status string `json:"status"`
+	Status  string `json:"status"`
+	Route   string `json:"route"`
+	Version string `json:"version"`
+	GitSha  string `json:"git_sha"`
 }
 
 // GetStatus returns the value of Status.
@@ -175,9 +178,39 @@ func (s *HealthOK) GetStatus() string {
 	return s.Status
 }
 
+// GetRoute returns the value of Route.
+func (s *HealthOK) GetRoute() string {
+	return s.Route
+}
+
+// GetVersion returns the value of Version.
+func (s *HealthOK) GetVersion() string {
+	return s.Version
+}
+
+// GetGitSha returns the value of GitSha.
+func (s *HealthOK) GetGitSha() string {
+	return s.GitSha
+}
+
 // SetStatus sets the value of Status.
 func (s *HealthOK) SetStatus(val string) {
 	s.Status = val
+}
+
+// SetRoute sets the value of Route.
+func (s *HealthOK) SetRoute(val string) {
+	s.Route = val
+}
+
+// SetVersion sets the value of Version.
+func (s *HealthOK) SetVersion(val string) {
+	s.Version = val
+}
+
+// SetGitSha sets the value of GitSha.
+func (s *HealthOK) SetGitSha(val string) {
+	s.GitSha = val
 }
 
 func (*HealthOK) healthRes() {}

--- a/api/pkg/ent/openapi.json
+++ b/api/pkg/ent/openapi.json
@@ -177,10 +177,22 @@
                   "properties": {
                     "status": {
                       "type": "string"
+                    },
+                    "route": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "git_sha": {
+                      "type": "string"
                     }
                   },
                   "required": [
-                    "status"
+                    "status",
+                    "route",
+                    "version",
+                    "git_sha"
                   ]
                 }
               }

--- a/api/pkg/ent/ts/schema.d.ts
+++ b/api/pkg/ent/ts/schema.d.ts
@@ -189,6 +189,9 @@ export interface operations {
         content: {
           "application/json": {
             status: string;
+            route: string;
+            version: string;
+            git_sha: string;
           };
         };
       };

--- a/api/pkg/request/health_handler.go
+++ b/api/pkg/request/health_handler.go
@@ -29,10 +29,10 @@ func (h HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	b, err := json.Marshal(status)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(fmt.Sprintf("Failed to convert %s to json", status)))
+		w.Write([]byte(fmt.Sprintf("Failed to convert %s to json", status))) //nolint:errcheck
 		return
 	}
-	w.Write(b)
+	w.Write(b) //nolint:errcheck
 }
 
 func HealthOKResponse(path string) model.HealthResponse {

--- a/api/pkg/request/health_handler.go
+++ b/api/pkg/request/health_handler.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/chanzuckerberg/happy/shared/model"
@@ -28,7 +29,8 @@ func (h HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	b, err := json.Marshal(status)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("Failed to convert HealthResponse to json"))
+		w.Write([]byte(fmt.Sprintf("Failed to convert %s to json", status)))
+		return
 	}
 	w.Write(b)
 }

--- a/api/pkg/request/version_check_handler.go
+++ b/api/pkg/request/version_check_handler.go
@@ -56,10 +56,10 @@ func (h VersionCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	b, err := json.Marshal(resp)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(fmt.Sprintf("Failed to convert %s to json", resp)))
+		w.Write([]byte(fmt.Sprintf("Failed to convert %s to json", resp))) //nolint:errcheck
 		return
 	}
-	w.Write(b)
+	w.Write(b) //nolint:errcheck
 }
 
 func validateUserAgentVersion(userAgent string) error {

--- a/api/pkg/request/version_check_handler.go
+++ b/api/pkg/request/version_check_handler.go
@@ -1,6 +1,8 @@
 package request
 
 import (
+	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/blang/semver"
@@ -24,7 +26,7 @@ func init() {
 	}
 }
 
-func VersionCheckHandler(c *fiber.Ctx) error {
+func VersionCheckHandlerFiber(c *fiber.Ctx) error {
 	userAgent := string(c.Request().Header.UserAgent())
 	err := validateUserAgentVersion(userAgent)
 	if err != nil {
@@ -34,6 +36,20 @@ func VersionCheckHandler(c *fiber.Ctx) error {
 	}
 
 	return c.Status(fiber.StatusOK).JSON(map[string]string{"message": ""})
+}
+
+type VersionCheckHandler struct{}
+
+func (h VersionCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	userAgent := r.Header.Get("User-Agent")
+	err := validateUserAgentVersion(userAgent)
+	message := ""
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		message = err.Error()
+	}
+
+	w.Write([]byte(fmt.Sprintf("%v", map[string]string{"message": message})))
 }
 
 func validateUserAgentVersion(userAgent string) error {


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2066:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2066" title="CCIE-2066" target="_blank">CCIE-2066</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Finallize entoas/ogent read-only routes in Happy API</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Done</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

After implementing the new routing in support of /v2 routes, anything that was previously a root route (ie `/health`) in Fiber became inaccessible because only routes prefixed with `/v1` were routed to the Fiber app. This prevented liveness probes from getting a success response and the API was not able to deploy. This moves health and versionCheck routes to the root mux instead of the Fiber app and rewrites tests to be agnostic to the backend router framework.