### PR TITLE
fix: Happy terminates if the service configured in config.json doesn't get deployed in a specific environment

### DIFF
--- a/shared/workspace_repo/workspace.go
+++ b/shared/workspace_repo/workspace.go
@@ -346,11 +346,11 @@ func (s *TFEWorkspace) WaitWithOptions(ctx context.Context, waitOptions options.
 		status := run.Status
 
 		if waitOptions.Orchestrator != nil && !printedAlert && len(waitOptions.StackName) > 0 && time.Since(startTimestamp) > alertAfter {
-			// TODO(el): A more helpful message
 			logrus.Warn("This apply is taking an unusually long time. Are your containers crashing?")
+			// Not all services defined in config will be in the stack (e.g. if they are not deployed in this environment)
 			err = waitOptions.Orchestrator.GetEvents(ctx, waitOptions.StackName, waitOptions.Services)
 			if err != nil {
-				return err
+				logrus.Errorf("failed to get events: %s", err.Error())
 			}
 			printedAlert = true
 		}


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2153:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2153" title="CCIE-2153" target="_blank">CCIE-2153</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy terminates if the service configured in config.json doesn't get deployed in a specific environment</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

null