### PR TITLE
chore: fix failing integration-test filter when triggered by push

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+      - CCIE-2165-integration-test-fails-when-multiple-tests-run-in-parallel
   pull_request: {}
   schedule:
     - cron: '0 11 * * *'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,6 +20,7 @@ jobs:
       should_run_integration_tests: ${{ steps.check_branch.outputs.result }}
     steps:
     - name: Check if integration-test file changed
+      if: ${{ github.event_name == 'pull_request' }}
       uses: dorny/paths-filter@v2
       id: integration_test_changes
       with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - CCIE-2165-integration-test-fails-when-multiple-tests-run-in-parallel
   pull_request: {}
   schedule:
     - cron: '0 11 * * *'
@@ -20,6 +19,7 @@ jobs:
       should_run_integration_tests: ${{ steps.check_branch.outputs.result }}
     steps:
     - name: Check if integration-test file changed
+      # the output of this step is only used if the run was triggered by a pull_request
       if: ${{ github.event_name == 'pull_request' }}
       uses: dorny/paths-filter@v2
       id: integration_test_changes


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2165:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2165" title="CCIE-2165" target="_blank">CCIE-2165</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Integration test fails when multiple tests run in parallel</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

We can't use the step to check if certain files changed unless it is a PR that triggered the run