### PR TITLE
feat: move cors configuration to root mux

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/ogen-go/ogen v0.81.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
+	github.com/rs/cors v1.10.1
 	github.com/samber/lo v1.39.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2

--- a/api/go.sum
+++ b/api/go.sum
@@ -388,6 +388,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
+github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=

--- a/api/pkg/api/app.go
+++ b/api/pkg/api/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/chanzuckerberg/happy/api/pkg/setup"
 	"github.com/chanzuckerberg/happy/api/pkg/store"
 	"github.com/gofiber/fiber/v2/middleware/adaptor"
+	"github.com/rs/cors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -45,5 +46,8 @@ func MakeAPIApplication(ctx context.Context, cfg *setup.Configuration, db *store
 }
 
 func (a *APIApplication) Listen() error {
-	return http.ListenAndServe(fmt.Sprintf(":%d", a.cfg.Api.Port), a.mux)
+	c := cors.New(cors.Options{
+		AllowedHeaders: []string{"Authorization", "Content-Type", "x-aws-access-key-id", "x-aws-secret-access-key", "x-aws-session-token", "baggage", "sentry-trace"},
+	})
+	return http.ListenAndServe(fmt.Sprintf(":%d", a.cfg.Api.Port), c.Handler(a.mux))
 }

--- a/api/pkg/api/app_fiber.go
+++ b/api/pkg/api/app_fiber.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/gofiber/contrib/fibersentry"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/gofiber/fiber/v2/middleware/requestid"
 	"github.com/gofiber/swagger"
@@ -38,9 +37,6 @@ func MakeFiberServer(cfg *setup.Configuration) *FiberServer {
 func MakeFiberApp(ctx context.Context, cfg *setup.Configuration, db *store.DB) *FiberServer {
 	apiApp := MakeFiberServer(cfg).WithDatabase(db)
 	apiApp.FiberApp.Use(requestid.New())
-	apiApp.FiberApp.Use(cors.New(cors.Config{
-		AllowHeaders: "Authorization,Content-Type,x-aws-access-key-id,x-aws-secret-access-key,x-aws-session-token,baggage,sentry-trace",
-	}))
 	apiApp.configureLogger(cfg.Api)
 	apiApp.FiberApp.Use(func(c *fiber.Ctx) error {
 		err := request.VersionCheckHandlerFiber(c)


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2216:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2216" title="CCIE-2216" target="_blank">CCIE-2216</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Configure CORS for v2 routes</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Move the CORS configuration to the root mux so it applies to both v1 and v2 routes, allowing `/v2/app-configs` to be used by EngPortal's Happy plugin