### PR TITLE
fix: make CORS policy allow delete requests

### DIFF
--- a/api/pkg/api/app.go
+++ b/api/pkg/api/app.go
@@ -48,6 +48,7 @@ func MakeAPIApplication(ctx context.Context, cfg *setup.Configuration, db *store
 func (a *APIApplication) Listen() error {
 	c := cors.New(cors.Options{
 		AllowedHeaders: []string{"Authorization", "Content-Type", "x-aws-access-key-id", "x-aws-secret-access-key", "x-aws-session-token", "baggage", "sentry-trace"},
+		AllowedMethods: []string{http.MethodGet, http.MethodPost, http.MethodHead, http.MethodDelete},
 	})
 	return http.ListenAndServe(fmt.Sprintf(":%d", a.cfg.Api.Port), c.Handler(a.mux))
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2216:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2216" title="CCIE-2216" target="_blank">CCIE-2216</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Configure CORS for v2 routes</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Done</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Default allowed methods are `http.MethodGet, http.MethodPost, http.MethodHead` but we also need to allow delete requests