### PR TITLE
fix: omit stack when config source == 'environment'

### DIFF
--- a/api/pkg/api/config_v2.go
+++ b/api/pkg/api/config_v2.go
@@ -165,6 +165,7 @@ func (h handler) ListAppConfig(ctx context.Context, params ogent.ListAppConfigPa
 
 	results := make(map[string]struct {
 		source ogent.AppConfigListSource
+		stack  string
 		value  []byte
 	})
 	for key, value := range envSecrets {
@@ -173,10 +174,12 @@ func (h handler) ListAppConfig(ctx context.Context, params ogent.ListAppConfigPa
 		}
 		results[key] = struct {
 			source ogent.AppConfigListSource
+			stack  string
 			value  []byte
 		}{
 			source: ogent.AppConfigListSourceEnvironment,
 			value:  value,
+			stack:  "", // leave empty since it's an environment secret
 		}
 	}
 
@@ -193,9 +196,11 @@ func (h handler) ListAppConfig(ctx context.Context, params ogent.ListAppConfigPa
 			}
 			results[key] = struct {
 				source ogent.AppConfigListSource
+				stack  string
 				value  []byte
 			}{
 				source: ogent.AppConfigListSourceStack,
+				stack:  stack,
 				value:  value,
 			}
 		}
@@ -203,14 +208,10 @@ func (h handler) ListAppConfig(ctx context.Context, params ogent.ListAppConfigPa
 
 	var configs []ogent.AppConfigList
 	for key, secret := range results {
-		stackForConfig := stack
-		if secret.source == ogent.AppConfigListSourceEnvironment {
-			stackForConfig = ""
-		}
 		configs = append(configs, ogent.AppConfigList{
 			AppName:     params.AppName,
 			Environment: params.Environment,
-			Stack:       stackForConfig,
+			Stack:       secret.stack,
 			Source:      secret.source,
 			Key:         key,
 			Value:       string(secret.value),

--- a/api/pkg/api/config_v2.go
+++ b/api/pkg/api/config_v2.go
@@ -203,10 +203,14 @@ func (h handler) ListAppConfig(ctx context.Context, params ogent.ListAppConfigPa
 
 	var configs []ogent.AppConfigList
 	for key, secret := range results {
+		stackForConfig := stack
+		if secret.source == ogent.AppConfigListSourceEnvironment {
+			stackForConfig = ""
+		}
 		configs = append(configs, ogent.AppConfigList{
 			AppName:     params.AppName,
 			Environment: params.Environment,
-			Stack:       stack,
+			Stack:       stackForConfig,
 			Source:      secret.source,
 			Key:         key,
 			Value:       string(secret.value),


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2217:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2217" title="CCIE-2217" target="_blank">CCIE-2217</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Implement v2 API calls in eng-portal</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Leaves the value of `stack` in the API responses blank for env-level configs