### PR TITLE
fix: Fix command usage for happy restart

### DIFF
--- a/cli/cmd/restart.go
+++ b/cli/cmd/restart.go
@@ -25,8 +25,9 @@ func init() {
 }
 
 var restartCmd = &cobra.Command{
-	Use:          "restart",
-	Short:        "Restart a happy stack deployment, leaving everything else the same",
+	Use:          "restart STACK_NAME",
+	Long:         "Sequentially restart containers for each service in a stack (usually to apply configuration updates)",
+	Short:        "Restart containers for the stack STACK_NAME",
 	SilenceUsage: true,
 	PreRunE: happyCmd.Validate(
 		cobra.ExactArgs(1),


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2299:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2299" title="CCIE-2299" target="_blank">CCIE-2299</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Fix command usage for happy restart</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

null