### PR TITLE
fix: aws_profile not always required

### DIFF
--- a/shared/model/app_stack.go
+++ b/shared/model/app_stack.go
@@ -29,7 +29,7 @@ type StackMetadata struct {
 }
 
 type AWSContext struct {
-	AWSProfile     string `query:"aws_profile"      validate:"required"`
+	AWSProfile     string `query:"aws_profile"`
 	AWSRegion      string `query:"aws_region"       validate:"required"`
 	TaskLaunchType string `query:"task_launch_type" validate:"required,oneof=fargate k8s"`
 	K8SNamespace   string `query:"k8s_namespace"    validate:"required_if=TaskLaunchType k8s"`


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2333:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2333" title="CCIE-2333" target="_blank">CCIE-2333</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>ONCALL API error</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-2333

## Summary

When calling the API from a Github Action, we don't specify an AWSProfile since there are none. Removing this validation so folks can write Github Actions that call the API.