### PR TITLE
fix: update cleanup action to not error out

### DIFF
--- a/.github/workflows/cleanup-playground.yml
+++ b/.github/workflows/cleanup-playground.yml
@@ -52,7 +52,7 @@ jobs:
           role-duration-seconds: 1800
           role-session-name: HappyCleanupPlaygroundStacks
       - name: Clean up stale happy stacks
-        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.4.0
+        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.6.1
         with:
           tfe_token: ${{secrets.TFE_TOKEN_PLAYGROUND}}
           time: 1 minutes
@@ -83,7 +83,7 @@ jobs:
           role-duration-seconds: 1800
           role-session-name: HappyCleanupPlaygroundStacks
       - name: Clean up stale happy stacks
-        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.4.0
+        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.6.1
         with:
           tfe_token: ${{secrets.TFE_TOKEN_PLAYGROUND}}
           time: 1 minutes
@@ -114,7 +114,7 @@ jobs:
           role-duration-seconds: 1800
           role-session-name: HappyCleanupPlaygroundStacks
       - name: Clean up stale happy stacks
-        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.4.0
+        uses: chanzuckerberg/github-actions/.github/actions/happy-cleanup@happy-cleanup-v1.6.1
         with:
           tfe_token: ${{secrets.TFE_TOKEN_PLAYGROUND}}
           time: 1 minutes


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2114:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2114" title="CCIE-2114" target="_blank">CCIE-2114</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy cleanup doesn't run</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Done</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-2114

`Error: request failed with: failed to get oidc token: failed to get token: Unable to extract token from client: could not read from keyring: exec: "dbus-launch": executable file not found in $PATH`

https://github.com/chanzuckerberg/github-actions/pull/248