### PR TITLE
fix: printing logs when TFE plan fails

### DIFF
--- a/shared/workspace_repo/workspace.go
+++ b/shared/workspace_repo/workspace.go
@@ -395,9 +395,11 @@ func (s *TFEWorkspace) WaitWithOptions(ctx context.Context, waitOptions options.
 				if err != nil {
 					logrus.Errorf("failed to get events: %s", err.Error())
 				}
-				err = waitOptions.Orchestrator.PrintLogs(ctx, waitOptions.StackName, waitOptions.Services)
-				if err != nil {
-					logrus.Errorf("failed to retrieve logs: %s", err.Error())
+				if options.DebugLogsDuringDeploymentFromCtx(ctx) {
+					err = waitOptions.Orchestrator.PrintLogs(ctx, waitOptions.StackName, waitOptions.Services)
+					if err != nil {
+						logrus.Errorf("failed to retrieve logs: %s", err.Error())
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2592:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2592" title="CCIE-2592" target="_blank">CCIE-2592</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy: Do not print logs when env var HAPPY_SKIP_LOGS=true is set</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>Done</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-2592](https://czi-tech.atlassian.net/browse/CCIE-2592)

## Summary

There is one more place where pod logs are printed. When the TFE plan fails, it was also printing logs.

[CCIE-2592]: https://czi-tech.atlassian.net/browse/CCIE-2592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ