### PR TITLE
fix: use patched oidc_cli version

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/aws/aws-sdk-go-v2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.35.1
-	github.com/chanzuckerberg/go-misc/oidc_cli v0.0.0-20240405164810-70208e5dc77a
+	github.com/chanzuckerberg/go-misc/oidc_cli v0.0.0-20240503165711-6d466da677c5
 	github.com/chanzuckerberg/go-misc/sets v0.0.0-20240405164810-70208e5dc77a
 	github.com/chanzuckerberg/happy/shared v0.0.0
 	github.com/fatih/color v1.16.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -294,8 +294,8 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chanzuckerberg/go-misc/oidc_cli v0.0.0-20240405164810-70208e5dc77a h1:RrBV/+BCQyRJ7VGILsFnszuwvShrGk8eWsY4Umhnp8Q=
-github.com/chanzuckerberg/go-misc/oidc_cli v0.0.0-20240405164810-70208e5dc77a/go.mod h1:ogMmcHO1nKTzDGrdogtWS4StwZFLZ+COEyiEaxg++cw=
+github.com/chanzuckerberg/go-misc/oidc_cli v0.0.0-20240503165711-6d466da677c5 h1:oUJgrp6QZdlxb/FbBf9Kc2LoNNkEJ1ZGTrDaHhsYX3Q=
+github.com/chanzuckerberg/go-misc/oidc_cli v0.0.0-20240503165711-6d466da677c5/go.mod h1:ogMmcHO1nKTzDGrdogtWS4StwZFLZ+COEyiEaxg++cw=
 github.com/chanzuckerberg/go-misc/osutil v0.0.0-20240404182313-43e397411f6e h1:/JeLD/XX6AEa5JDtObkskuzGEIZUq8dG4su64jpmaA4=
 github.com/chanzuckerberg/go-misc/osutil v0.0.0-20240404182313-43e397411f6e/go.mod h1:b9dYrz3Z7wNqSnvbxJUaPuAeTu9xRbKdiaMy2Ptx70E=
 github.com/chanzuckerberg/go-misc/pidlock v0.0.0-20240320212149-709d6d5c338b h1:OgmOweR3uiAFvF+kBqFbepGLgzJT9H+PS1t7JQmomNQ=


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2717:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2717" title="CCIE-2717" target="_blank">CCIE-2717</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy list fails to decompress uncompressed token</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-2717

When an older (uncompressed) token was cached and someone used a new version of the CLI we'd hit this error:
```
» happy list                                                                                                                                           
[INFO]: Listing stacks from the happy api
[FATAL]: request failed with: failed to get oidc token: failed to get token: Unable to extract token from client: failed to decompress token: failed to create gzip reader: gzip: invalid header
```

https://github.com/chanzuckerberg/go-misc/pull/1058 - `oidc_cli` was patched to treat a failure to decompress as a cache miss, refreshing the token