### PR TITLE
feat: increase the ALB idle timeout period

### DIFF
--- a/api/.happy/terraform/envs/prod/main.tf
+++ b/api/.happy/terraform/envs/prod/main.tf
@@ -16,6 +16,7 @@ module "stack" {
       platform_architecture = "arm64"
       port                  = 3001
       service_type          = "EXTERNAL"
+      alb_idle_timeout      = 300
     }
   }
   routing_method = "CONTEXT"
@@ -32,6 +33,6 @@ module "stack" {
 module "event_bus" {
   source = "./modules/event-bus"
 
-  stack_name     = var.stack_name
-  k8s_namespace  = var.k8s_namespace
+  stack_name    = var.stack_name
+  k8s_namespace = var.k8s_namespace
 }

--- a/api/.happy/terraform/envs/rdev/main.tf
+++ b/api/.happy/terraform/envs/rdev/main.tf
@@ -16,6 +16,7 @@ module "stack" {
       platform_architecture = "arm64"
       port                  = 3001
       service_type          = "EXTERNAL" # TODO: work on making API INTNERAL in the future
+      alb_idle_timeout      = 300
     }
   }
   routing_method = "CONTEXT"
@@ -32,6 +33,6 @@ module "stack" {
 module "event_bus" {
   source = "./modules/event-bus"
 
-  stack_name     = var.stack_name
-  k8s_namespace  = var.k8s_namespace
+  stack_name    = var.stack_name
+  k8s_namespace = var.k8s_namespace
 }

--- a/api/.happy/terraform/envs/staging/main.tf
+++ b/api/.happy/terraform/envs/staging/main.tf
@@ -16,6 +16,7 @@ module "stack" {
       platform_architecture = "arm64"
       port                  = 3001
       service_type          = "EXTERNAL" # TODO: work on making API INTNERAL in the future
+      alb_idle_timeout      = 300
     }
   }
   routing_method = "CONTEXT"
@@ -32,6 +33,6 @@ module "stack" {
 module "event_bus" {
   source = "./modules/event-bus"
 
-  stack_name     = var.stack_name
-  k8s_namespace  = var.k8s_namespace
+  stack_name    = var.stack_name
+  k8s_namespace = var.k8s_namespace
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2722:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2722" title="CCIE-2722" target="_blank">CCIE-2722</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>https://czi-tech.atlassian.net/browse/ONCALL-776</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-2722

## Summary
<img width="1565" alt="Screenshot 2024-05-06 at 11 49 10 AM" src="https://github.com/chanzuckerberg/happy/assets/76011913/3cba1c31-09fe-4995-bb36-9355882e814a">

This PR increases the idle timeout period for HAPI. Some of the list operations take a little longer and we don't want to return 504 when that happens (like on clean up stack).

## References:

* https://chanzuckerbergteam.slack.com/archives/C04NVSCDFR7/p1714430262918409
* https://github.com/chanzuckerberg/bento/actions/runs/8902558405/job/24645287282

