### PR TITLE
fix: Upgrade default RDS certificate bundle for happy-env-ecs to rds-ca-ecc384-g1

### DIFF
--- a/terraform/modules/happy-env-ecs/db.tf
+++ b/terraform/modules/happy-env-ecs/db.tf
@@ -30,7 +30,7 @@ module "db" {
   instance_class             = each.value.instance_class
   instance_count             = 1
   vpc_id                     = var.cloud-env.vpc_id
-  ca_cert_identifier         = "rds-ca-2019"
+  ca_cert_identifier         = "rds-ca-ecc384-g1"
   auto_minor_version_upgrade = false
   db_deletion_protection     = true
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2832:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2832" title="CCIE-2832" target="_blank">CCIE-2832</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Update default happy RDS CA identifier</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-2832]

[CCIE-2832]: https://czi-tech.atlassian.net/browse/CCIE-2832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ