### PR TITLE
fix: Restore the HAPI entrypoint

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -42,4 +42,4 @@ ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local
 RUN update-ca-certificates
 RUN openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt | openssl pkcs7 -print_certs -noout | grep ECC384
 
-# ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2924:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2924" title="CCIE-2924" target="_blank">CCIE-2924</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Install certificate bundle into hapi container</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-2924]

[CCIE-2924]: https://czi-tech.atlassian.net/browse/CCIE-2924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ