### PR TITLE
fix: Update default CA identifier to rds-ca-rsa2048-g1

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -37,9 +37,9 @@ RUN go install github.com/cespare/reflex@v0.3.1
 COPY ./entrypoint.sh .
 
 RUN apk add openssl
-RUN openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt | openssl pkcs7 -print_certs -noout | grep ECC384 || true
+RUN openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt | openssl pkcs7 -print_certs -noout | grep RSA2048 || true
 ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem /usr/local/share/ca-certificates/global-bundle.crt
 RUN update-ca-certificates
-RUN openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt | openssl pkcs7 -print_certs -noout | grep ECC384
+RUN openssl crl2pkcs7 -nocrl -certfile /etc/ssl/certs/ca-certificates.crt | openssl pkcs7 -print_certs -noout | grep RSA2048
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/terraform/modules/happy-env-ecs/db.tf
+++ b/terraform/modules/happy-env-ecs/db.tf
@@ -30,7 +30,7 @@ module "db" {
   instance_class             = each.value.instance_class
   instance_count             = 1
   vpc_id                     = var.cloud-env.vpc_id
-  ca_cert_identifier         = "rds-ca-ecc384-g1"
+  ca_cert_identifier         = "rds-ca-rsa2048-g1"
   auto_minor_version_upgrade = false
   db_deletion_protection     = true
 }

--- a/terraform/modules/happy-env-eks/db.tf
+++ b/terraform/modules/happy-env-eks/db.tf
@@ -25,7 +25,7 @@ module "dbs" {
   instance_class             = each.value.instance_class
   instance_count             = 1
   vpc_id                     = var.cloud-env.vpc_id
-  ca_cert_identifier         = "rds-ca-ecc384-g1"
+  ca_cert_identifier         = "rds-ca-rsa2048-g1"
   auto_minor_version_upgrade = false
   db_deletion_protection     = true
   rds_cluster_parameters     = each.value.rds_cluster_parameters


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-2932:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-2932" title="CCIE-2932" target="_blank">CCIE-2932</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Modify happy-env-* modules to use rds-ca-rsa2048-g1 CA identifier</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-2932]

[CCIE-2932]: https://czi-tech.atlassian.net/browse/CCIE-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR modifies the happy-env-eks and happy-env-ecs modules to use the `rds-ca-rsa2048-g1` CA identifier, as 
`rds-ca-ecc384-g1` requires TLS 1.3, which is not currently compatible with AWS Aurora.