### PR TITLE
fix: Add empty string check to service_account_name

### DIFF
--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -36,7 +36,7 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
     "spec" = {
       "identityRefs" = concat([for v in var.allow_mesh_services : {
         "kind"      = "ServiceAccount"
-        "name"      = v.service_account_name != null ? v.service_account_name : "${v.stack}-${v.service}-${var.deployment_stage}-${v.stack}"
+        "name"      = v.service_account_name != null && v.service_account_name != "" ? v.service_account_name : "${v.stack}-${v.service}-${var.deployment_stage}-${v.stack}"
         "namespace" = var.k8s_namespace
         }], local.allow_ingress_controller ? [{
         "kind"      = "ServiceAccount"


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3091:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-3091" title="CCIE-3091" target="_blank">CCIE-3091</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Add empty string check to service_account_name</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10315?size=medium" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

CCIE-3091
https://czi-tech.atlassian.net/browse/CCIE-3091

For the `allow_mesh_services` list, we need to supply elements with mixed configuration, stack/service and service_account_name. This is new, previously we mostly only used stack/service

But since mixed structures are not allowed, I had to set empty strings for the values not needed, which caused the incorrect part of ternary to be executed. 

This PR adds an additional non-empty string check, to ensure that only when a valid string is used for identity.

Testing - 
Tested on rdev by using the main ref happy, and then once again by using this branch as ref. As expected, first run failed, and the second succeeded.

First failed run - https://si.prod.tfe.czi.technology/app/happy-edu-platform/workspaces/rdev-rdr-adnanrhussa/runs/run-BjutJYYG9uL66B16

Second passed run - https://si.prod.tfe.czi.technology/app/happy-edu-platform/workspaces/rdev-rdr-adnanrhussa/runs/run-gChoVfAvtYQxEkRX
