### PR TITLE
feat!: allow cloudfront module to use multiple origins

### DIFF
--- a/terraform/modules/happy-cloudfront/.validate/main.tf
+++ b/terraform/modules/happy-cloudfront/.validate/main.tf
@@ -5,10 +5,23 @@ module "test_validate" {
     domain_name = "example.com"
     zone_id     = "1234567890"
   }
-  origin = {
-    domain_name = "example.com"
+  origins = [
+    {
+      domain_name  = "example1.com"
+      path_pattern = "/api/oauth/*"
+    },
+    {
+      domain_name  = "example2.com"
+      path_pattern = "/"
+    }
+  ]
+  tags = {
+    owner     = ""
+    service   = ""
+    project   = ""
+    env       = ""
+    managedBy = ""
   }
-  tags = {}
   providers = {
     aws.useast1 = aws.useast1
   }

--- a/terraform/modules/happy-cloudfront/README.md
+++ b/terraform/modules/happy-cloudfront/README.md
@@ -12,7 +12,6 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.14 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5 |
 
 ## Modules
 
@@ -27,7 +26,6 @@
 | [aws_cloudfront_distribution.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
 | [aws_route53_record.alias_ipv4](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.alias_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
@@ -39,8 +37,8 @@
 | <a name="input_cache_policy_id"></a> [cache\_policy\_id](#input\_cache\_policy\_id) | The cache policy ID for the CloudFront distribution. | `string` | `"4135ea2d-6df8-44a3-9df3-4b5a84be39ad"` | no |
 | <a name="input_frontend"></a> [frontend](#input\_frontend) | The domain name and zone ID the user will see. | <pre>object({<br>    domain_name = string<br>    zone_id     = string<br>  })</pre> | n/a | yes |
 | <a name="input_geo_restriction_locations"></a> [geo\_restriction\_locations](#input\_geo\_restriction\_locations) | The countries to whitelist for the CloudFront distribution. | `set(string)` | <pre>[<br>  "US"<br>]</pre> | no |
-| <a name="input_origin"></a> [origin](#input\_origin) | The domain name of the origin. | <pre>object({<br>    domain_name = string<br>  })</pre> | n/a | yes |
 | <a name="input_origin_request_policy_id"></a> [origin\_request\_policy\_id](#input\_origin\_request\_policy\_id) | The origin request policy ID for the CloudFront distribution. | `string` | `"b689b0a8-53d0-40ab-baf2-68738e2966ac"` | no |
+| <a name="input_origins"></a> [origins](#input\_origins) | The domain names and the path used for the origin. | <pre>list(object({<br>    domain_name  = string<br>    path_pattern = string<br>  }))</pre> | n/a | yes |
 | <a name="input_price_class"></a> [price\_class](#input\_price\_class) | The price class for the CloudFront distribution. | `string` | `"PriceClass_100"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to associate with env resources | `map(string)` | n/a | yes |
 

--- a/terraform/modules/happy-cloudfront/variables.tf
+++ b/terraform/modules/happy-cloudfront/variables.tf
@@ -6,11 +6,16 @@ variable "frontend" {
   description = "The domain name and zone ID the user will see."
 }
 
-variable "origin" {
-  type = object({
-    domain_name = string
-  })
-  description = "The domain name of the origin."
+variable "origins" {
+  type = list(object({
+    domain_name  = string
+    path_pattern = string
+  }))
+  description = "The domain names and the path used for the origin."
+  validation {
+    condition     = length(var.origins) > 0
+    error_message = "Must provide a least 1 origin"
+  }
 }
 
 variable "cache" {


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3093:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-3093" title="CCIE-3093" target="_blank">CCIE-3093</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Make CloudFront Module Accept Multiple Origins</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

People might want to route traffic from one "frontend" endpoint to other endpoints. This change assumes that the path of the frontend domain maps to the same kind of destination endpoint. For example:

example.com/api/oauth -> example2.com/api/oauth

or 

example.com/ -> example2.com/

If you need to deviate from this pattern, you'd have to refactor the `origin`, `cache` blocks, and `variables` to make it work. 
https://czi-tech.atlassian.net/browse/CCIE-3093