### PR TITLE
feat: allow status page for all happy services

### DIFF
--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -1,6 +1,7 @@
 locals {
   allow_ingress_controller = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
   needs_policy             = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
+  global_allow_list = ["edu-platform-${var.deployment_stage}-status-page"]
 }
 
 resource "kubernetes_manifest" "linkerd_server" {
@@ -42,7 +43,7 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
         "kind"      = "ServiceAccount"
         "name"      = "nginx-ingress-ingress-nginx"
         "namespace" = "nginx-encrypted-ingress"
-      }] : [])
+      }] : [], global_allow_list)
     }
   }
 }

--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -1,7 +1,7 @@
 locals {
   allow_ingress_controller = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
   needs_policy             = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
-  global_allow_list = ["edu-platform-${var.deployment_stage}-status-page"]
+  global_allow_list        = ["edu-platform-${var.deployment_stage}-status-page"]
 }
 
 resource "kubernetes_manifest" "linkerd_server" {

--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -43,7 +43,7 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
         "kind"      = "ServiceAccount"
         "name"      = "nginx-ingress-ingress-nginx"
         "namespace" = "nginx-encrypted-ingress"
-      }] : [], global_allow_list)
+      }] : [], local.global_allow_list)
     }
   }
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3100:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-3100" title="CCIE-3100" target="_blank">CCIE-3100</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy allow for status page internal</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-3100