### PR TITLE
fix: make the cloudfront comment static so we won't reach length errors

### DIFF
--- a/terraform/modules/happy-cloudfront/main.tf
+++ b/terraform/modules/happy-cloudfront/main.tf
@@ -11,13 +11,9 @@ module "cert" {
   }
 }
 
-locals {
-  domains = join(",", [for index, value in var.origins : "${value.domain_name}${value.path_pattern}"])
-}
-
 resource "aws_cloudfront_distribution" "this" {
   enabled     = true
-  comment     = "Forward requests from ${var.frontend.domain_name} to ${local.domains}."
+  comment     = "Forward requests from alias to the origins"
   price_class = var.price_class
   aliases     = [var.frontend.domain_name]
 


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3093:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-3093" title="CCIE-3093" target="_blank">CCIE-3093</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Make CloudFront Module Accept Multiple Origins</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

I blew past the maximum comment length, but I don't believe we should enforce lengths on the domains we set. This seems like a good-enough tradeoff.

https://czi-tech.atlassian.net/browse/CCIE-3093