### PR TITLE
fix: revert "feat: allow status page for all happy services"

### DIFF
--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -1,7 +1,6 @@
 locals {
   allow_ingress_controller = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
   needs_policy             = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
-  global_allow_list        = ["edu-platform-${var.deployment_stage}-status-page"]
 }
 
 resource "kubernetes_manifest" "linkerd_server" {
@@ -43,7 +42,7 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
         "kind"      = "ServiceAccount"
         "name"      = "nginx-ingress-ingress-nginx"
         "namespace" = "nginx-encrypted-ingress"
-      }] : [], local.global_allow_list)
+      }] : [])
     }
   }
 }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3110:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-3110" title="CCIE-3110" target="_blank">CCIE-3110</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Fix Issue with IdentityRef format in linkerd</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi-tech.atlassian.net/browse/CCIE-3110

Reverts chanzuckerberg/happy#3414

Issue - https://si.prod.tfe.czi.technology/app/happy-edu-platform/workspaces/staging-cts/runs/run-oS9Kpgupg5gGgKTe