### PR TITLE
feat: allow status page for all happy services

### DIFF
--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -1,6 +1,7 @@
 locals {
   allow_ingress_controller = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
   needs_policy             = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
+  global_allow_list = ["edu-platform-${var.deployment_stage}-status-page"]
 }
 
 resource "kubernetes_manifest" "linkerd_server" {
@@ -42,7 +43,7 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
         "kind"      = "ServiceAccount"
         "name"      = "nginx-ingress-ingress-nginx"
         "namespace" = "nginx-encrypted-ingress"
-      }] : [])
+      }] : [], global_allow_list)
     }
   }
 }

--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -1,8 +1,8 @@
 locals {
-  allow_ingress_controller                    = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
-  needs_policy                                = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
+  allow_ingress_controller = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
+  needs_policy             = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
   # Service accounts that we want to allow access to this protected service
-  mesh_services_service_accounts              = [for v in var.allow_mesh_services : {
+  mesh_services_service_accounts = [for v in var.allow_mesh_services : {
     "kind"      = "ServiceAccount"
     "name"      = v.service_account_name != null && v.service_account_name != "" ? v.service_account_name : "${v.stack}-${v.service}-${var.deployment_stage}-${v.stack}"
     "namespace" = var.k8s_namespace
@@ -12,7 +12,7 @@ locals {
     "name"      = "nginx-ingress-ingress-nginx"
     "namespace" = "nginx-encrypted-ingress"
   }] : []
-  status_page_service_account                 = [{
+  status_page_service_account = [{
     "kind"      = "ServiceAccount"
     "name"      = "edu-platform-${var.deployment_stage}-status-page"
     "namespace" = "status-page"

--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -45,11 +45,12 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
           "name"      = "nginx-ingress-ingress-nginx"
           "namespace" = "nginx-encrypted-ingress"
         }] : [],
-        [{
-          "kind"      = "ServiceAccount"
-          "name"      = "edu-platform-${var.deployment_stage}-status-page"
-          "namespace" = "status-page"
-        }]
+        # [{
+        #   "kind"      = "ServiceAccount"
+        #   "name"      = "edu-platform-${var.deployment_stage}-status-page"
+        #   "namespace" = "status-page"
+        # }]
+        ["edu-platform-${var.deployment_stage}-status-page"]
       )
     }
   }

--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -1,7 +1,7 @@
 locals {
   allow_ingress_controller = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
   needs_policy             = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
-  global_allow_list = ["edu-platform-${var.deployment_stage}-status-page"]
+  global_allow_list        = ["edu-platform-${var.deployment_stage}-status-page"]
 }
 
 resource "kubernetes_manifest" "linkerd_server" {

--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -45,12 +45,11 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
           "name"      = "nginx-ingress-ingress-nginx"
           "namespace" = "nginx-encrypted-ingress"
         }] : [],
-        # [{
-        #   "kind"      = "ServiceAccount"
-        #   "name"      = "edu-platform-${var.deployment_stage}-status-page"
-        #   "namespace" = "status-page"
-        # }]
-        ["edu-platform-${var.deployment_stage}-status-page"]
+        [{
+          "kind"      = "ServiceAccount"
+          "name"      = "edu-platform-${var.deployment_stage}-status-page"
+          "namespace" = "status-page"
+        }]
       )
     }
   }

--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -43,7 +43,7 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
         "kind"      = "ServiceAccount"
         "name"      = "nginx-ingress-ingress-nginx"
         "namespace" = "nginx-encrypted-ingress"
-      }] : [], global_allow_list)
+      }] : [], local.global_allow_list)
     }
   }
 }

--- a/terraform/modules/happy-mesh-access-control/main.tf
+++ b/terraform/modules/happy-mesh-access-control/main.tf
@@ -1,6 +1,22 @@
 locals {
-  allow_ingress_controller = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
-  needs_policy             = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
+  allow_ingress_controller                    = var.service_type == "EXTERNAL" || var.service_type == "INTERNAL" || var.service_type == "VPC"
+  needs_policy                                = local.allow_ingress_controller || length(var.allow_mesh_services) > 0
+  # Service accounts that we want to allow access to this protected service
+  mesh_services_service_accounts              = [for v in var.allow_mesh_services : {
+    "kind"      = "ServiceAccount"
+    "name"      = v.service_account_name != null && v.service_account_name != "" ? v.service_account_name : "${v.stack}-${v.service}-${var.deployment_stage}-${v.stack}"
+    "namespace" = var.k8s_namespace
+  }]
+  optional_ingress_controller_service_account = local.allow_ingress_controller ? [{
+    "kind"      = "ServiceAccount"
+    "name"      = "nginx-ingress-ingress-nginx"
+    "namespace" = "nginx-encrypted-ingress"
+  }] : []
+  status_page_service_account                 = [{
+    "kind"      = "ServiceAccount"
+    "name"      = "edu-platform-${var.deployment_stage}-status-page"
+    "namespace" = "status-page"
+  }]
 }
 
 resource "kubernetes_manifest" "linkerd_server" {
@@ -35,21 +51,9 @@ resource "kubernetes_manifest" "linkerd_mesh_tls_authentication" {
     }
     "spec" = {
       "identityRefs" = concat(
-        [for v in var.allow_mesh_services : {
-          "kind"      = "ServiceAccount"
-          "name"      = v.service_account_name != null && v.service_account_name != "" ? v.service_account_name : "${v.stack}-${v.service}-${var.deployment_stage}-${v.stack}"
-          "namespace" = var.k8s_namespace
-        }],
-        local.allow_ingress_controller ? [{
-          "kind"      = "ServiceAccount"
-          "name"      = "nginx-ingress-ingress-nginx"
-          "namespace" = "nginx-encrypted-ingress"
-        }] : [],
-        [{
-          "kind"      = "ServiceAccount"
-          "name"      = "edu-platform-${var.deployment_stage}-status-page"
-          "namespace" = "status-page"
-        }]
+        local.mesh_services_service_accounts,
+        local.optional_ingress_controller_service_account,
+        local.status_page_service_account
       )
     }
   }


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3100:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi-tech.atlassian.net/browse/CCIE-3100" title="CCIE-3100" target="_blank">CCIE-3100</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Happy allow for status page internal</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi-tech.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[CCIE-3100](https://czi-tech.atlassian.net/browse/CCIE-3100)

We had to revert https://github.com/chanzuckerberg/happy/pull/3414 due to Issue - https://si.prod.tfe.czi.technology/app/happy-edu-platform/workspaces/staging-cts/runs/run-oS9Kpgupg5gGgKTe

In this PR. I am making the status-page entry consistent with other items in the list

### Testing - Pending

Intentional bad test case - https://si.prod.tfe.czi.technology/app/happy-edu-platform/workspaces/rdev-idy-adnanrhussa/runs/run-eaojRa23CXTQJndv

Post-fix test case that succeeded - https://si.prod.tfe.czi.technology/app/happy-edu-platform/workspaces/rdev-idy-adnanrhussa/runs/run-nfgfsPrt294LYJzc

[CCIE-3100]: https://czi-tech.atlassian.net/browse/CCIE-3100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ