### PR TITLE
fix: update Jira PR and Jira Release actions after czi-tech => czi Jira migration

### DIFF
--- a/.github/workflows/api-release-prod.yaml
+++ b/.github/workflows/api-release-prod.yaml
@@ -60,9 +60,9 @@ jobs:
     needs:
       - check-api-released
       - release-api # we need to wait for the release to finish before creating the jira version
-    uses: chanzuckerberg/github-actions/.github/workflows/jira-release-version.yaml@v1.20.4
+    uses: chanzuckerberg/github-actions/.github/workflows/jira-release-version.yaml@v2.13.1
     with:
-      projectID: '10006'
+      projectID: '12399'
       projectKey: CCIE
       jiraVersionPrefix: 'Happy'
     secrets:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -80,9 +80,9 @@ jobs:
     needs:
       - check-cli-released
       - go-release-cli # we need to wait for the release to finish before creating the jira version
-    uses: chanzuckerberg/github-actions/.github/workflows/jira-release-version.yaml@v1.20.4
+    uses: chanzuckerberg/github-actions/.github/workflows/jira-release-version.yaml@v2.13.1
     with:
-      projectID: '10006'
+      projectID: '12399'
       projectKey: CCIE
       jiraVersionPrefix: 'Happy'
     secrets:

--- a/.github/workflows/hvm-release.yaml
+++ b/.github/workflows/hvm-release.yaml
@@ -80,9 +80,9 @@ jobs:
     needs:
       - check-hvm-released
       - go-release-hvm # we need to wait for the release to finish before creating the jira version
-    uses: chanzuckerberg/github-actions/.github/workflows/jira-release-version.yaml@v1.20.4
+    uses: chanzuckerberg/github-actions/.github/workflows/jira-release-version.yaml@v2.13.1
     with:
-      projectID: '10006'
+      projectID: '12399'
       projectKey: CCIE
       jiraVersionPrefix: 'Happy'
     secrets:

--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Validate Jira Reference
         id: validateJiraReference
-        uses: chanzuckerberg/github-actions/.github/actions/jira-validate-reference@jira-validate-reference-v1.1.1
+        uses: chanzuckerberg/github-actions/.github/actions/jira-validate-reference@jira-validate-reference-v1.1.2
         with:
           jiraToken: ${{ secrets.JIRA_TOKEN }}
           projectKey: CCIE


### PR DESCRIPTION
- Update to use new actions that have the correct Jira URLs
- Update project ID for CCIE