### PR TITLE
fix: don't panic when an OIDC provider doesn't exist anymore

### DIFF
--- a/api/pkg/request/auth.go
+++ b/api/pkg/request/auth.go
@@ -214,7 +214,8 @@ func MakeVerifierFromConfig(ctx context.Context, cfg *setup.Configuration) OIDCV
 	for _, provider := range cfg.Auth.Providers {
 		verifier, err := MakeOIDCProvider(ctx, provider.IssuerURL, provider.ClientID, DefaultClaimsVerifier)
 		if err != nil {
-			logrus.Fatalf("failed to create OIDC verifier with error: %s", err.Error())
+			logrus.Errorf("failed to create OIDC verifier with error: %s", err.Error())
+			continue
 		}
 		verifiers = append(verifiers, verifier)
 	}


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3389:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-3389" title="CCIE-3389" target="_blank">CCIE-3389</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Fix Happy API to not panic when we clean up old OIDC providers</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Review</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi.atlassian.net/browse/CCIE-3389