### PR TITLE
fix: Restrict happy datadog synthetics to us-east-1 and us-west-2

### DIFF
--- a/terraform/modules/happy-datadog-synthetics/README.md
+++ b/terraform/modules/happy-datadog-synthetics/README.md
@@ -21,7 +21,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [datadog_synthetics_test.test_api](https://registry.terraform.io/providers/datadog/datadog/latest/docs/resources/synthetics_test) | resource |
-| [datadog_synthetics_locations.locations](https://registry.terraform.io/providers/datadog/datadog/latest/docs/data-sources/synthetics_locations) | data source |
 
 ## Inputs
 

--- a/terraform/modules/happy-datadog-synthetics/main.tf
+++ b/terraform/modules/happy-datadog-synthetics/main.tf
@@ -1,5 +1,3 @@
-data "datadog_synthetics_locations" "locations" {}
-
 resource "datadog_synthetics_test" "test_api" {
   type    = "api"
   subtype = "http"
@@ -12,7 +10,7 @@ resource "datadog_synthetics_test" "test_api" {
     operator = "is"
     target   = "200"
   }
-  locations = keys(data.datadog_synthetics_locations.locations.locations)
+  locations = ["aws:us-east-1", "aws:us-west-2"]
   options_list {
     tick_every = 900
 


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3479:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-3479" title="CCIE-3479" target="_blank">CCIE-3479</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Reduce number of synthetic check locations used for happy stacks to us-east-1 and us-west-2</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

[ONCALL-937] [CCIE-3479]

[ONCALL-937]: https://czi.atlassian.net/browse/ONCALL-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCIE-3479]: https://czi.atlassian.net/browse/CCIE-3479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ