### PR TITLE
fix: only create synthetics if they request it

### DIFF
--- a/terraform/modules/happy-stack-eks/synthetics.tf
+++ b/terraform/modules/happy-stack-eks/synthetics.tf
@@ -10,6 +10,7 @@ locals {
   # and no synthetics to the internal URLs created for the services.
   additional_hosts_synthetics = merge([for k, v in local.service_definitions :
     { for domain in var.additional_hostnames : v.service_name => "https://${domain}${v.health_check_path}" }
+    if v.synthetics && (v.service_type == "EXTERNAL" || v.service_type == "INTERNAL")
   ]...)
 
 


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3522:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-3522" title="CCIE-3522" target="_blank">CCIE-3522</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Too many synthetics being made for custom happy domains</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi.atlassian.net/browse/CCIE-3522

## Summary

Noticed there were some faulty synthetics for custom production domains. After reviewing the code, these [projects](https://github.com/chanzuckerberg/bento/blob/main/apps/login/.happy/terraform/envs/prod/main.tf) didn't actually have synthetics turned on, but its because this file will make synthetics for all custom domains, regardless of if you set it. Adding a filter to only add synthetics if specified by the service.