### PR TITLE
fix: deprecated --rm-dist flag for goreleaser

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           version: latest
           workdir: cli
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ steps.parse_version.outputs.result }}

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -1,5 +1,6 @@
 package cmd
 
+// bump
 import (
 	"github.com/chanzuckerberg/happy/cli/pkg/hapi"
 	"github.com/chanzuckerberg/happy/shared/config"

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -1,6 +1,5 @@
 package cmd
 
-// bump
 import (
 	"github.com/chanzuckerberg/happy/cli/pkg/hapi"
 	"github.com/chanzuckerberg/happy/shared/config"


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3758:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-3758" title="CCIE-3758" target="_blank">CCIE-3758</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Upgrade TFE Prod</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Story" src="https://czi.atlassian.net/images/icons/issuetypes/story.svg" />
        Story
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi.atlassian.net/browse/CCIE-3758

https://github.com/hashicorp/ghaction-terraform-provider-release/issues/36