### PR TITLE
fix: if one oidc verifier is failing, do not let the whole API fail

### DIFF
--- a/api/pkg/request/auth.go
+++ b/api/pkg/request/auth.go
@@ -214,7 +214,7 @@ func MakeVerifierFromConfig(ctx context.Context, cfg *setup.Configuration) OIDCV
 	for _, provider := range cfg.Auth.Providers {
 		verifier, err := MakeOIDCProvider(ctx, provider.IssuerURL, provider.ClientID, DefaultClaimsVerifier)
 		if err != nil {
-			logrus.Warnf("failed to create OIDC verifier with error: %s", err.Error())
+			logrus.Warnf("failed to create OIDC verifier with Issuer URL %s and clientID %s with error: %s", provider.IssuerURL, provider.ClientID, err.Error())
 			continue
 		}
 		verifiers = append(verifiers, verifier)


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3867:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-3867" title="CCIE-3867" target="_blank">CCIE-3867</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Fix Happy API error</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Sometimes there's an OIDC configuration that doesn't work, but we shouldn't make the entire Happy API fail because of that. In this change, we spit out a warning and an additional warning if there's only one verifier. 

https://czi.atlassian.net/browse/CCIE-3867