### PR TITLE
feat: Add sameSite configuration to happy_sticky_session cookie

### DIFF
--- a/terraform/modules/happy-ingress-eks/variables.tf
+++ b/terraform/modules/happy-ingress-eks/variables.tf
@@ -100,6 +100,7 @@ variable "routing" {
       enabled          = optional(bool, false),
       duration_seconds = optional(number, 600),
       cookie_name      = optional(string, "happy_sticky_session"),
+      cookie_samesite  = optional(string, "Lax"),
     }), {})
   })
   description = "Routing configuration for the ingress"

--- a/terraform/modules/happy-nginx-ingress-eks/README.md
+++ b/terraform/modules/happy-nginx-ingress-eks/README.md
@@ -31,7 +31,7 @@ No modules.
 | <a name="input_ingress_name"></a> [ingress\_name](#input\_ingress\_name) | Name of the ingress resource | `string` | n/a | yes |
 | <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | K8S namespace for this service | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to ingress resource | `map(string)` | n/a | yes |
-| <a name="input_sticky_sessions"></a> [sticky\_sessions](#input\_sticky\_sessions) | Sticky session configuration | <pre>object({<br>    enabled          = optional(bool, true),<br>    duration_seconds = optional(number, 600),<br>    cookie_name      = optional(string, "happy_sticky_session"),<br>  })</pre> | `{}` | no |
+| <a name="input_sticky_sessions"></a> [sticky\_sessions](#input\_sticky\_sessions) | Sticky session configuration | <pre>object({<br>    enabled          = optional(bool, true),<br>    duration_seconds = optional(number, 600),<br>    cookie_name      = optional(string, "happy_sticky_session"),<br>    cookie_samesite  = optional(string, "Lax"),<br>  })</pre> | `{}` | no |
 | <a name="input_target_service_name"></a> [target\_service\_name](#input\_target\_service\_name) | Name of destination service that the ingress should route to | `string` | n/a | yes |
 | <a name="input_target_service_port"></a> [target\_service\_port](#input\_target\_service\_port) | Port of destination service that the ingress should route to | `string` | n/a | yes |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout for the ingress resource | `number` | `60` | no |

--- a/terraform/modules/happy-nginx-ingress-eks/main.tf
+++ b/terraform/modules/happy-nginx-ingress-eks/main.tf
@@ -1,9 +1,10 @@
 
 locals {
   sticky_annotations = {
-    "nginx.ingress.kubernetes.io/affinity"               = "cookie"
-    "nginx.ingress.kubernetes.io/session-cookie-name"    = var.sticky_sessions.cookie_name
-    "nginx.ingress.kubernetes.io/session-cookie-max-age" = var.sticky_sessions.duration_seconds
+    "nginx.ingress.kubernetes.io/affinity"                 = "cookie"
+    "nginx.ingress.kubernetes.io/session-cookie-name"      = var.sticky_sessions.cookie_name
+    "nginx.ingress.kubernetes.io/session-cookie-max-age"   = var.sticky_sessions.duration_seconds
+    "nginx.ingress.kubernetes.io/session-cookie-samesite"  = var.sticky_sessions.cookie_samesite
   }
 
   base_annotations = {

--- a/terraform/modules/happy-nginx-ingress-eks/variables.tf
+++ b/terraform/modules/happy-nginx-ingress-eks/variables.tf
@@ -47,6 +47,7 @@ variable "sticky_sessions" {
     enabled          = optional(bool, true),
     duration_seconds = optional(number, 600),
     cookie_name      = optional(string, "happy_sticky_session"),
+    cookie_samesite  = optional(string, "Lax"),
   })
   description = "Sticky session configuration"
   default     = {}

--- a/terraform/modules/happy-service-eks/variables.tf
+++ b/terraform/modules/happy-service-eks/variables.tf
@@ -334,6 +334,7 @@ variable "routing" {
       enabled          = optional(bool, false),
       duration_seconds = optional(number, 600),
       cookie_name      = optional(string, "happy_sticky_session"),
+      cookie_samesite  = optional(string, "Lax"),
     }), {})
   })
   description = "Routing configuration for the ingress"

--- a/terraform/modules/happy-stack-eks/variables.tf
+++ b/terraform/modules/happy-stack-eks/variables.tf
@@ -119,6 +119,7 @@ variable "services" {
       enabled          = optional(bool, false),
       duration_seconds = optional(number, 600),
       cookie_name      = optional(string, "happy_sticky_session"),
+      cookie_samesite  = optional(string, "Lax"),
     }), {})
     sidecars = optional(map(object({
       image                     = string


### PR DESCRIPTION
The configuration is optional with a default of "Lax"

Along needs this feature for sticky sessions when running in an iframe, configured as `SameSite` "None" 

"Lax" is the default setting for all major browsers.