### PR TITLE
fix: Fix the default sticky session behavior in happy-nginx-ingress-eks

### DIFF
--- a/terraform/modules/happy-service-eks/main.tf
+++ b/terraform/modules/happy-service-eks/main.tf
@@ -739,6 +739,7 @@ module "nginx-ingress" {
   target_service_port = var.routing.service_port
   timeout             = var.routing.alb_idle_timeout
   labels              = local.labels
+  sticky_sessions     = each.value.sticky_sessions
 }
 
 module "mesh-access-control" {

--- a/terraform/modules/happy-stack-eks/README.md
+++ b/terraform/modules/happy-stack-eks/README.md
@@ -1,4 +1,4 @@
-<!-- bump3 -->
+<!-- bump4 -->
 <!-- START -->
 ## Requirements
 


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3991:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-3991" title="CCIE-3991" target="_blank">CCIE-3991</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>bug: Happy ignores sticky session settings</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Bug" src="https://czi.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />
        Bug
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>To Do</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi.atlassian.net/browse/CCIE-3991