### PR TITLE
fix: Update runs-on labels in GitHub Actions workflows

### DIFF
--- a/.github/workflows/api-release-npm.yml
+++ b/.github/workflows/api-release-npm.yml
@@ -5,7 +5,7 @@ on:
 name: api-release-npm
 jobs:
   check-api-released:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Check Release
         id: api_released
@@ -17,7 +17,7 @@ jobs:
       api_released: ${{ steps.api_released.outputs.result }}
 
   publish-npm-package:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     if: ${{ needs.check-api-released.outputs.api_released == 'true' }}
     needs:
       - check-api-released

--- a/.github/workflows/api-release-prod.yaml
+++ b/.github/workflows/api-release-prod.yaml
@@ -9,7 +9,7 @@ concurrency:
 name: api-release-prod
 jobs:
   check-api-released:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Check Release
         id: api_released
@@ -21,7 +21,7 @@ jobs:
       api_released: ${{ steps.api_released.outputs.result }}
 
   release-api:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     if: ${{ needs.check-api-released.outputs.api_released == 'true' }}
     needs:
       - check-api-released

--- a/.github/workflows/api-release-staging.yaml
+++ b/.github/workflows/api-release-staging.yaml
@@ -9,7 +9,7 @@ concurrency:
 name: api-release-staging
 jobs:
   release-api:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/api-update-docs.yml
+++ b/.github/workflows/api-update-docs.yml
@@ -7,7 +7,7 @@ concurrency:
 name: api-docs
 jobs:
   api_changes:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       pull-requests: read
     outputs:
@@ -25,7 +25,7 @@ jobs:
   update-api-docs:
     needs: api_changes
     if: ${{ needs.api_changes.outputs.run_api_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/api-update-ent-schema.yml
+++ b/.github/workflows/api-update-ent-schema.yml
@@ -7,7 +7,7 @@ concurrency:
 name: api-ent-schema
 jobs:
   api_changes:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       pull-requests: read
     outputs:
@@ -25,7 +25,7 @@ jobs:
   update-api-ent-schema:
     needs: api_changes
     if: ${{ needs.api_changes.outputs.run_api_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/automerge-dep.yml
+++ b/.github/workflows/automerge-dep.yml
@@ -8,7 +8,7 @@ concurrency:
     cancel-in-progress: true
 jobs:
   dependabot:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Generate token

--- a/.github/workflows/charts-release.yml
+++ b/.github/workflows/charts-release.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   check-chart-released:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Check Release
         id: chart_released
@@ -27,7 +27,7 @@ jobs:
     needs:
       - check-chart-released
     # NOTE: needs to be X64 because of helm-releaser
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Parse Version
         id: parse_version

--- a/.github/workflows/cleanup-playground.yml
+++ b/.github/workflows/cleanup-playground.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   find-examples:
     name: Find examples
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     outputs:
       examples: ${{ steps.findExamples.outputs.examples }}
     steps:
@@ -35,7 +35,7 @@ jobs:
       run:
         working-directory: ./examples/${{matrix.example}}
     name: Clean rdev happy stacks
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       id-token: write
       contents: read
@@ -66,7 +66,7 @@ jobs:
       run:
         working-directory: ./examples/${{matrix.example}}
     name: Clean staging happy stacks
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       id-token: write
       contents: read
@@ -97,7 +97,7 @@ jobs:
       run:
         working-directory: ./examples/${{matrix.example}}
     name: Clean prod happy stacks
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -7,7 +7,7 @@ concurrency:
 name: cli-build
 jobs:
   cli_changes:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       pull-requests: read
     outputs:
@@ -25,7 +25,7 @@ jobs:
   lint-cli:
     needs: cli_changes
     if: ${{ needs.cli_changes.outputs.run_cli_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -47,7 +47,7 @@ jobs:
   test-cli:
     needs: cli_changes
     if: ${{ needs.cli_changes.outputs.run_cli_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -8,7 +8,7 @@ concurrency:
 name: release-cli
 jobs:
   check-cli-released:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Check Release
         id: cli_released
@@ -20,7 +20,7 @@ jobs:
       cli_released: ${{ steps.cli_released.outputs.result }}
 
   go-release-cli:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     if: ${{ needs.check-cli-released.outputs.cli_released == 'true' }}
     needs:
       - check-cli-released

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -14,6 +14,6 @@ concurrency:
   cancel-in-progress: true
 jobs:
   conventional_commit_title:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.3.1

--- a/.github/workflows/hvm-ci.yml
+++ b/.github/workflows/hvm-ci.yml
@@ -7,7 +7,7 @@ concurrency:
 name: hvm-build
 jobs:
   hvm_changes:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       pull-requests: read
     outputs:
@@ -25,7 +25,7 @@ jobs:
   lint-cli:
     needs: hvm_changes
     if: ${{ needs.cli_changes.outputs.run_hvm_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -47,7 +47,7 @@ jobs:
   test-cli:
     needs: hvm_changes
     if: ${{ needs.hvm_changes.outputs.run_hvm_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/hvm-release.yaml
+++ b/.github/workflows/hvm-release.yaml
@@ -8,7 +8,7 @@ concurrency:
 name: release-hvm
 jobs:
   check-hvm-released:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Check Release
         id: hvm_released
@@ -20,7 +20,7 @@ jobs:
       hvm_released: ${{ steps.hvm_released.outputs.result }}
 
   go-release-hvm:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     if: ${{ needs.check-hvm-released.outputs.hvm_released == 'true' }}
     needs:
       - check-hvm-released

--- a/.github/workflows/jira-pr.yaml
+++ b/.github/workflows/jira-pr.yaml
@@ -10,7 +10,7 @@ name: Jira PR
 
 jobs:
   validate_jira_reference:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Validate Jira Reference
         id: validateJiraReference

--- a/.github/workflows/provider-ci.yml
+++ b/.github/workflows/provider-ci.yml
@@ -8,7 +8,7 @@ concurrency:
 name: provider-build
 jobs:
   provider_changes:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       pull-requests: read
     outputs:
@@ -26,7 +26,7 @@ jobs:
   lint-provider:
     needs: provider_changes
     if: ${{ needs.provider_changes.outputs.run_provider_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -45,7 +45,7 @@ jobs:
   test-provider:
     needs: provider_changes
     if: ${{ needs.provider_changes.outputs.run_provider_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -7,7 +7,7 @@ concurrency:
 name: release-provider
 jobs:
   check-provider-released:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Check Release
         id: provider_released
@@ -19,7 +19,7 @@ jobs:
       provider_released: ${{ steps.provider_released.outputs.result }}
 
   go-release-provider:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     if: ${{ needs.check-provider-released.outputs.provider_released == 'true' }}
     needs:
       - check-provider-released

--- a/.github/workflows/provider-update-docs.yml
+++ b/.github/workflows/provider-update-docs.yml
@@ -8,7 +8,7 @@ concurrency:
 name: provider-docs
 jobs:
   provider_changes:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       pull-requests: read
     outputs:
@@ -26,7 +26,7 @@ jobs:
   update-provider-docs:
     needs: provider_changes
     if: ${{ needs.provider_changes.outputs.run_provider_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,7 +8,7 @@ concurrency:
 name: release-please
 jobs:
   release-please:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       # For why we need to generate a token and not use the default

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -8,7 +8,7 @@ concurrency:
 name: shared-build
 jobs:
   shared_changes:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       pull-requests: read
     outputs:
@@ -26,7 +26,7 @@ jobs:
   lint-shared:
     needs: shared_changes
     if: ${{ needs.shared_changes.outputs.run_shared_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -48,7 +48,7 @@ jobs:
   test-shared:
     needs: shared_changes
     if: ${{ needs.shared_changes.outputs.run_shared_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -64,7 +64,7 @@ jobs:
   update-go-mod:
     needs: shared_changes
     if: ${{ needs.shared_changes.outputs.run_shared_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/tf-ci.yml
+++ b/.github/workflows/tf-ci.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   tf_module_changes:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     permissions:
       pull-requests: read
     outputs:
@@ -25,7 +25,7 @@ jobs:
   find-changed-dirs:
     needs: tf_module_changes
     if: ${{ needs.tf_module_changes.outputs.run_tf_modules_ci == 'true' }}
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     outputs:
       allChanges: ${{ steps.changedDirs.outputs.allChanges }}
     steps:
@@ -58,7 +58,7 @@ jobs:
             core.setOutput("allChanges", uniqueChangedDirs)
 
   lint-changed-dirs:
-    runs-on: [X64, self-hosted, Linux]
+    runs-on: X64
     needs: [find-changed-dirs, tf_module_changes]
     strategy:
       matrix:


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-3911:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-3911" title="CCIE-3911" target="_blank">CCIE-3911</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Deprecate "self-hosted" and "Linux" tags</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

https://czi.atlassian.net/browse/CCIE-3911

This PR updates 'runs-on' in GitHub Actions workflow files to use direct values instead of label arrays.