### PR TITLE
fix: remove depguard from happy linter (CCIE-4307)

### DIFF
--- a/terraform/provider/.golangci.yml
+++ b/terraform/provider/.golangci.yml
@@ -12,24 +12,6 @@ linters-settings:
       - ^fmt\.Print.*$
       - ^spew\.Dump$
       - ^println$
-  depguard:
-    list-type: denylist
-    include-go-root: true
-    packages-with-error-message:
-      - errors: "please use github.com/pkg/errors instead"
-      - golang.org/x/xerrors: "please use github.com/pkg/errors instead"
-      - gopkg.in/yaml.v2: "please use gopkg.in/yaml.v3 instead"
-    additional-guards:
-      # Do not allow test code into "real" code
-      - list-type: denylist
-        include-go-root: false
-        packages:
-          - github.com/stretchr/testify
-          - github.com/happy/pkg/backend/aws/testbackend
-        ignore-file-rules:
-          - "**/*_test.go"
-          - "**/mock/**/*.go"
-          - "pkg/backend/aws/testbackend/*.go"
 issues:
   exclude-rules:
     # Exclude some linters from running on tests files.


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-4307:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-4307" title="CCIE-4307" target="_blank">CCIE-4307</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Fix Happy Linter</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Sub-task" src="https://czi.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10311?size=medium" />
        Sub-task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Lint had a breaking change a while back involving depguard drastically rewriting the structure of its config (https://github.com/golangci/golangci-lint/issues/3906) . I took a stab at rewriting to meet the new standard (https://golangci-lint.run/usage/linters/#depguard) but in realizing what this specific linter did, it didn't seem worth debugging the associated versioning and formatting issues. As this specific linter was primarily being used to ensure we were not using incorrect error packages, and doesn't otherwise monitor the health of the application, I think it can be safely removed. It's more important to get this linter passing overall so that we can push through dependabot fixes.