### PR TITLE
fix: Pin happy-tfe-okta-app in happy-env-eks

### DIFF
--- a/terraform/modules/happy-env-eks/README.md
+++ b/terraform/modules/happy-env-eks/README.md
@@ -28,7 +28,7 @@ https://docs.google.com/drawings/d/1AsJts2qCmw7685A6WZPDb5ApkXyuPRc27Lg3zzWuPaA/
 | <a name="module_dbs"></a> [dbs](#module\_dbs) | github.com/chanzuckerberg/cztack//aws-aurora-postgres | v0.49.0 |
 | <a name="module_ecrs"></a> [ecrs](#module\_ecrs) | git@github.com:chanzuckerberg/cztack//aws-ecr-repo | v0.59.0 |
 | <a name="module_happy_github_ci_role"></a> [happy\_github\_ci\_role](#module\_happy\_github\_ci\_role) | ../happy-github-ci-role | n/a |
-| <a name="module_happy_okta_app"></a> [happy\_okta\_app](#module\_happy\_okta\_app) | ../happy-tfe-okta-app | n/a |
+| <a name="module_happy_okta_app"></a> [happy\_okta\_app](#module\_happy\_okta\_app) | git@github.com:chanzuckerberg/happy//terraform/modules/happy-tfe-okta-app | happy-tfe-okta-app-v3.1.0 |
 | <a name="module_happy_service_account"></a> [happy\_service\_account](#module\_happy\_service\_account) | ../happy-tfe-okta-service-account | n/a |
 | <a name="module_ops-genie"></a> [ops-genie](#module\_ops-genie) | git@github.com:chanzuckerberg/shared-infra//terraform/modules/ops-genie-service | main |
 | <a name="module_s3_buckets"></a> [s3\_buckets](#module\_s3\_buckets) | github.com/chanzuckerberg/cztack//aws-s3-private-bucket | v0.56.2 |

--- a/terraform/modules/happy-env-eks/oidc.tf
+++ b/terraform/modules/happy-env-eks/oidc.tf
@@ -1,5 +1,5 @@
 module "happy_okta_app" {
-  source = "../happy-tfe-okta-app"
+  source = "git@github.com:chanzuckerberg/happy//terraform/modules/happy-tfe-okta-app?ref=happy-tfe-okta-app-v3.1.0"
 
   app_name = var.tags.project
   env      = var.tags.env


### PR DESCRIPTION
<!--JIRA_VALIDATE_START:CCIE-4359:do not remove this marker as it will break the jira validation functionality-->
<details open>
  <summary><a href="https://czi.atlassian.net/browse/CCIE-4359" title="CCIE-4359" target="_blank">CCIE-4359</a></summary>
  <br />
  <table>
    <tr>
      <th>Summary</th>
  <td>Upgrade okta provider</td>
    </tr>
    <tr>
      <th>Type</th>
      <td>
        <img alt="Task" src="https://czi.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />
        Task
      </td>
    </tr>
    <tr>
      <th>Status</th>
      <td>In Progress</td>
    </tr>
  </table>
</details>
<!--JIRA_VALIDATE_END:do not remove this marker as it will break the jira validation functionality-->

---

Need `happy-env-eks` to pick up most recent version of `happy-tfe-okta-app` with new provider version requirements.